### PR TITLE
fix compiler warning

### DIFF
--- a/rclc/include/rclc/rclc.h
+++ b/rclc/include/rclc/rclc.h
@@ -27,7 +27,7 @@ extern "C"
 
 /// Global initialization for rclc; should be called once per process.
 rclc_ret_t
-rclc_init(int argc, char ** argv);
+rclc_init(int argc, char const * const * argv);
 
 /// Global state check; returns false on user shutdown after ctrl-c.
 bool

--- a/rclc/src/functions.c
+++ b/rclc/src/functions.c
@@ -37,7 +37,7 @@
   } while (0)
 
 rclc_ret_t
-rclc_init(int argc, char ** argv)
+rclc_init(int argc, char const * const * argv)
 {
   rcl_ret_t rc = rcl_init(argc, argv, rcl_get_default_allocator());
   if (rc != RCL_RET_OK) {


### PR DESCRIPTION
Match signature with https://github.com/ros2/rcl/pull/223/files#diff-fcb08b6cee1da42633f5f2270d8a95d6R124 to avoid compiler warning.