### PR TITLE
Bugfix/resolve errors in bloom release

### DIFF
--- a/rclc/CHANGELOG.rst
+++ b/rclc/CHANGELOG.rst
@@ -1,6 +1,11 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package rclc
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.1.4 (2020-11-25)
+------------------
+* Fixed error in bloom release
+
 0.1.3 (2020-11-23)
 ------------------
 * Added rclc_lifecycle package

--- a/rclc/package.xml
+++ b/rclc/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>rclc</name>
-  <version>0.1.3</version>
+  <version>0.1.4</version>
   <description>The ROS client library in C.</description>
   <maintainer email="jan.staschulat@de.bosch.com">Jan Staschulat</maintainer>
   <maintainer email="pablogarrido@eprosima.com">Pablo Garrido</maintainer>

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -65,12 +65,12 @@ std_msgs__msg__Int32 * _pub_int_msg_ptr;
 
 // sleep time beween publish and receive in DDS middleware
 // to allow enough time on CI jobs (in milliseconds)
-#define RCLC_UNIT_TEST_SLEEP_TIME_MS 1000
+#define RCLC_UNIT_TEST_SLEEP_TIME_MS 100
 const std::chrono::milliseconds rclc_test_sleep_time =
   std::chrono::milliseconds(RCLC_UNIT_TEST_SLEEP_TIME_MS);
 
 // timeout for rcl_wait() when calling spin_some API of executor
-const uint64_t rclc_test_timeout_ns = 1000000000;  // 1s
+const uint64_t rclc_test_timeout_ns = 10000000000;  // 10s
 
 static
 void

--- a/rclc_examples/CHANGELOG.rst
+++ b/rclc_examples/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package rclc_examples
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.1.4 (2020-11-25)
+------------------
+* Fixed error in bloom release
+
 0.1.3 (2020-11-23)
 ------------------
 * Added rclc_lifecycle package

--- a/rclc_examples/package.xml
+++ b/rclc_examples/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>rclc_examples</name>
-  <version>0.1.3</version>
+  <version>0.1.4</version>
   <description>Example of using rclc_executor</description>
   <maintainer email="jan.staschulat@de.bosch.com">Jan Staschulat</maintainer>
 

--- a/rclc_lifecycle/CHANGELOG.rst
+++ b/rclc_lifecycle/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package rclc_lifecycle
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.1.4 (2020-11-25)
+------------------
+* Fixed error in bloom release
+
 0.1.3 (2020-11-23)
 ------------------
 * Aligned version number to rclc repository

--- a/rclc_lifecycle/package.xml
+++ b/rclc_lifecycle/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rclc_lifecycle</name>
-  <version>0.1.3</version>
+  <version>0.1.4</version>
   <description>rclc lifecycle convenience methods.</description>
   <maintainer email="jan.staschulat@de.bosch.com">Jan Staschulat</maintainer>
 


### PR DESCRIPTION
- added ament_cmake_gtest in package.xml in rclc_lifecycle (bug fix in bloom release build)
- increased waiting time of rclc_wait for unit tests of executor to 10s
- increased version to 0.1.4 (in all packages)
- created tag 0.1.4