### PR TITLE
resolving errors in units tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,11 @@ jobs:
     - uses: ros-tooling/setup-ros@0.0.26
       with:
         required-ros-distributions: ${{ matrix.ros_distribution }}
+    - name : Download and install rclc-dependencies
+      run: |
+        apt-get install ros-${{ matrix.ros_distribution }}-osrf-testing-tools-cpp
+        apt-get install ros-${{ matrix.ros_distribution }}-test-msgs
+
     - uses : ros-tooling/action-ros-ci@0.1.0
       with:
         package-name: "rclc rclc_examples rclc_lifecycle"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Please notice the following issues/limitations:
 
 ## Bloom Release Status of Code Repository ros2/rclc
 
-Bloom release status of packages in repository [github.com/ros2/rclc/](https://github.com/ros2/rclc) for different architectures and releases.
+Bloom release status of all packages in repository [github.com/ros2/rclc/](https://github.com/ros2/rclc) for different architectures and releases.
 
 |Package | Release | amd64 | arm64 | armhf |
 |:--     |  :--    |  :--  |  :--  | :--   |

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ The software is not ready for production use. It has neither been developed nor 
 
 Source your ROS2 `distribution` with `source /opt/ros/distribution/setup.bash`. Clone the repository into a ROS2 workspace (e.g. `~/ros2_ws/`) and build the packages using `colcon build` from the [Colcon Command Line Tools](https://colcon.readthedocs.io/en/released/). To test the RCLC package run `colcon test` or if you have multiple repositories in this workspace `colcon test --packages-select rclc`. For correct installation of the `rclc`-package do a `source ~/ros2_ws/install/local_setup.bash`. Then you are ready to run the examples in the `rclc_examples` package.
 
+The following repositories might not be in the default ROS 2 distribution: osrf_testing_tools_cpp and test_msgs. In this case install them manually (DISTRO beeing the name of your ROS 2 distribution):
+
+```C
+ sudo apt-get install ros-DISTRO-osrf-testing-tools-cpp
+ sudo apt-get install ros-DISTRO-test-msgs
+```
+
 ## License
 
 rclc is open-sourced under the Apache-2.0 license. See the [LICENSE](LICENSE) file for details.

--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -607,7 +607,7 @@ _rclc_take_new_data(rclc_executor_handle_t * handle, rcl_wait_set_t * wait_set)
     case SUBSCRIPTION:
       if (wait_set->subscriptions[handle->index]) {
         rmw_message_info_t messageInfo;
-        printf("DEBUG:rcl_take sub [%d] topic=%s\n", handle->index, 
+        printf("DEBUG:rcl_take sub [%ld] topic=%s\n", handle->index,
           rcl_subscription_get_topic_name(handle->subscription));
         rc = rcl_take(
           handle->subscription, handle->data, &messageInfo,

--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -1105,6 +1105,7 @@ bool rclc_executor_trigger_any(rclc_executor_handle_t * handles, unsigned int si
 bool rclc_executor_trigger_one(rclc_executor_handle_t * handles, unsigned int size, void * obj)
 {
   RCL_CHECK_FOR_NULL_WITH_MSG(handles, "handles is NULL", return false);
+  printf("rclc_executor_trigger_one ");
   // did not use (i<size && handles[i].initialized) as loop-condition
   // because for last index i==size this would result in out-of-bound access
   for (unsigned int i = 0; i < size; i++) {
@@ -1113,7 +1114,10 @@ bool rclc_executor_trigger_one(rclc_executor_handle_t * handles, unsigned int si
         switch (handles[i].type) {
           case SUBSCRIPTION:
             if (handles[i].subscription == obj) {
+              printf(" TRUE\n");
               return true;
+            } else {
+              printf(" FALSE\n");
             }
             break;
           case TIMER:

--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -607,7 +607,8 @@ _rclc_take_new_data(rclc_executor_handle_t * handle, rcl_wait_set_t * wait_set)
     case SUBSCRIPTION:
       if (wait_set->subscriptions[handle->index]) {
         rmw_message_info_t messageInfo;
-        printf("DEBUG:rcl_take sub [%ld] topic=%s\n", handle->index,
+        printf(
+          "DEBUG:rcl_take sub [%ld] topic=%s\n", handle->index,
           rcl_subscription_get_topic_name(handle->subscription));
         rc = rcl_take(
           handle->subscription, handle->data, &messageInfo,

--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -607,7 +607,8 @@ _rclc_take_new_data(rclc_executor_handle_t * handle, rcl_wait_set_t * wait_set)
     case SUBSCRIPTION:
       if (wait_set->subscriptions[handle->index]) {
         rmw_message_info_t messageInfo;
-        printf("DEBUG:rcl_take \n");
+        printf("DEBUG:rcl_take sub [%d] topic=%s\n", handle->index, 
+          rcl_subscription_get_topic_name(handle->subscription));
         rc = rcl_take(
           handle->subscription, handle->data, &messageInfo,
           NULL);

--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -540,7 +540,6 @@ _rclc_check_for_new_data(rclc_executor_handle_t * handle, rcl_wait_set_t * wait_
   switch (handle->type) {
     case SUBSCRIPTION:
       if (wait_set->subscriptions[handle->index]) {
-        printf("DEBUG: check_for_new_data: msg available\n");
         handle->data_available = true;
       }
       break;
@@ -607,9 +606,6 @@ _rclc_take_new_data(rclc_executor_handle_t * handle, rcl_wait_set_t * wait_set)
     case SUBSCRIPTION:
       if (wait_set->subscriptions[handle->index]) {
         rmw_message_info_t messageInfo;
-        printf(
-          "DEBUG:rcl_take sub [%ld] topic=%s\n", handle->index,
-          rcl_subscription_get_topic_name(handle->subscription));
         rc = rcl_take(
           handle->subscription, handle->data, &messageInfo,
           NULL);
@@ -1107,7 +1103,6 @@ bool rclc_executor_trigger_any(rclc_executor_handle_t * handles, unsigned int si
 bool rclc_executor_trigger_one(rclc_executor_handle_t * handles, unsigned int size, void * obj)
 {
   RCL_CHECK_FOR_NULL_WITH_MSG(handles, "handles is NULL", return false);
-  printf("rclc_executor_trigger_one ");
   // did not use (i<size && handles[i].initialized) as loop-condition
   // because for last index i==size this would result in out-of-bound access
   for (unsigned int i = 0; i < size; i++) {
@@ -1116,10 +1111,8 @@ bool rclc_executor_trigger_one(rclc_executor_handle_t * handles, unsigned int si
         switch (handles[i].type) {
           case SUBSCRIPTION:
             if (handles[i].subscription == obj) {
-              printf(" TRUE\n");
               return true;
             } else {
-              printf(" FALSE\n");
             }
             break;
           case TIMER:

--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -540,6 +540,7 @@ _rclc_check_for_new_data(rclc_executor_handle_t * handle, rcl_wait_set_t * wait_
   switch (handle->type) {
     case SUBSCRIPTION:
       if (wait_set->subscriptions[handle->index]) {
+        printf("DEBUG: check_for_new_data: msg available\n");
         handle->data_available = true;
       }
       break;
@@ -606,6 +607,7 @@ _rclc_take_new_data(rclc_executor_handle_t * handle, rcl_wait_set_t * wait_set)
     case SUBSCRIPTION:
       if (wait_set->subscriptions[handle->index]) {
         rmw_message_info_t messageInfo;
+        printf("DEBUG:rcl_take \n");
         rc = rcl_take(
           handle->subscription, handle->data, &messageInfo,
           NULL);

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -1524,7 +1524,7 @@ TEST_F(TestDefaultExecutor, trigger_one) {
   // ------------------------- test case setup ---------------------------------------------
 
   const std::chrono::milliseconds ci_job_time =
-    std::chrono::milliseconds(3000);
+    std::chrono::milliseconds(1000);
 
   // first round
   _results_callback_init();
@@ -1532,7 +1532,7 @@ TEST_F(TestDefaultExecutor, trigger_one) {
   rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
   printf("pub1 3\n");
   EXPECT_EQ(RCL_RET_OK, rc) << " pub1 did not publish!";
-  std::this_thread::sleep_for(rclc_test_sleep_time + ci_job_time);
+  std::this_thread::sleep_for(ci_job_time);
   rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
   EXPECT_EQ(_cb1_int_value, (unsigned int) 3) << " expected: A called";
   EXPECT_EQ(_cb2_int_value, (unsigned int) 0) << " expected: B not called";
@@ -1540,11 +1540,11 @@ TEST_F(TestDefaultExecutor, trigger_one) {
   EXPECT_EQ(_cb2_cnt, (unsigned int) 0);
   // second round
   this->pub2_msg.data = 787;
-  std::this_thread::sleep_for(rclc_test_sleep_time + ci_job_time);
+  std::this_thread::sleep_for(ci_job_time);
   rc = rcl_publish(&this->pub2, &this->pub2_msg, nullptr);
   printf("pub2 787\n");
   EXPECT_EQ(RCL_RET_OK, rc) << " pub2 did not publish!";
-  std::this_thread::sleep_for(rclc_test_sleep_time + ci_job_time);
+  std::this_thread::sleep_for(ci_job_time);
   rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
   EXPECT_EQ(_cb1_int_value, (unsigned int) 3) << " expected: A not called";
   EXPECT_EQ(_cb2_int_value, (unsigned int) 0) << " expected: B not called";
@@ -1553,6 +1553,7 @@ TEST_F(TestDefaultExecutor, trigger_one) {
 
   // third round
   this->pub1_msg.data = 11;
+  std::this_thread::sleep_for(ci_job_time);
   rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
   printf("pub1 11\n");
   EXPECT_EQ(RCL_RET_OK, rc) << " pub1 did not publish!";

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -77,7 +77,7 @@ static unsigned int gc1_cnt = 0;
 
 // sleep time beween publish and receive in DDS middleware
 // to allow enough time on CI jobs (in milliseconds)
-#define RCLC_UNIT_TEST_SLEEP_TIME_MS 200
+#define RCLC_UNIT_TEST_SLEEP_TIME_MS 500
 const std::chrono::milliseconds rclc_test_sleep_time =
   std::chrono::milliseconds(RCLC_UNIT_TEST_SLEEP_TIME_MS);
 

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -565,12 +565,12 @@ public:
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
     ret = rcl_context_fini(&this->context);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    std_msgs__msg__Int32__init(&this->pub1_msg);
-    std_msgs__msg__Int32__init(&this->pub2_msg);
-    std_msgs__msg__Int32__init(&pub3_msg);
-    std_msgs__msg__Int32__init(&this->pub1_msg);
-    std_msgs__msg__Int32__init(&this->pub2_msg);
-    std_msgs__msg__Int32__init(&pub3_msg);
+    std_msgs__msg__Int32__fini(&this->pub1_msg);
+    std_msgs__msg__Int32__fini(&this->pub2_msg);
+    std_msgs__msg__Int32__fini(&pub3_msg);
+    std_msgs__msg__Int32__fini(&this->pub1_msg);
+    std_msgs__msg__Int32__fini(&this->pub2_msg);
+    std_msgs__msg__Int32__fini(&pub3_msg);
   }
 };
 

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -218,7 +218,7 @@ _executor_results_compare(unsigned int * array)
     if (msg == NULL) { \
       printf("Test CB " #NUM ": msg is NULL\n"); \
     } else { \
-      printf("callback_" #NUM " was called\n"); \
+      printf("callback_" #NUM " received %d\n", msg->data); \
       _cb ## NUM ## _int_value = msg->data; \
     } \
     _cb ## NUM ## _cnt++; \

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -60,7 +60,7 @@ static unsigned int _cb3_cnt = 0;
 static unsigned int _cb3_int_value = 0;
 // callback for testing data communication semantics
 static unsigned int _cb5_cnt = 0;
-static unsigned int _cb5_int_value = 0;
+static int _cb5_int_value = 0;
 rcl_publisher_t * _pub_int_ptr;
 std_msgs__msg__Int32 * _pub_int_msg_ptr;
 
@@ -249,6 +249,7 @@ void int32_callback4(const void * msgin)
     if (rc != RCL_RET_OK) {
       printf("Error in int32_callback4: could not publish!\n");
     }
+    printf("cb4: published %d\n", _pub_int_msg_ptr->data);
     std::this_thread::sleep_for(std::chrono::milliseconds(1000));
   }
 }
@@ -261,7 +262,7 @@ void int32_callback5(const void * msgin)
   if (msg == NULL) {
     printf("(int32_callback5): msg is NULL\n");
   } else {
-    // printf("cb5 msg: %d\n", msg->data);
+    printf("cb5 msg: %d\n", msg->data);
     _cb5_int_value = msg->data;
   }
 }
@@ -1337,8 +1338,8 @@ TEST_F(TestDefaultExecutor, semantics_RCLCPP) {
   std::this_thread::sleep_for(rclc_test_sleep_time);
   rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
   // test result
-  EXPECT_EQ(_cb5_int_value, (unsigned int) 2) <<
-    " expect value 2: Value from callback of int32_callback4 should be received.";
+  EXPECT_EQ(_cb5_int_value, 2) <<
+    " expect value 2: Value from rcl_publish in int32_callback4 should have be received.";
 
   // clean-up
   rc = rcl_subscription_fini(&subscription2, &this->node);
@@ -1423,7 +1424,7 @@ TEST_F(TestDefaultExecutor, semantics_LET) {
   // test result
   EXPECT_EQ(
     _cb5_int_value,
-    (unsigned int) 1) <<
+    1) <<
     " expect value 1: first value of 'pub1' publisher should have been received.";
 
   // clean-up

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -82,7 +82,7 @@ const std::chrono::milliseconds rclc_test_sleep_time =
   std::chrono::milliseconds(RCLC_UNIT_TEST_SLEEP_TIME_MS);
 
 // timeout for rcl_wait() when calling spin_some API of executor
-const uint64_t rclc_test_timeout_ns = 10000000000;  // 10s
+const uint64_t rclc_test_timeout_ns = 1000000000;  // 1s
 
 static
 void
@@ -1089,12 +1089,14 @@ TEST_F(TestDefaultExecutor, invocation_type) {
   ///////////////////////////////////////////////////////////////////////////////////
   /////////// test case 1 : publish one data for each publisher
   ///////////////////////////////////////////////////////////////////////////////////
+  this->pub1_msg.data = 1;
+  this->pub2_msg.data = 2;
   ret = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
   EXPECT_EQ(RCL_RET_OK, ret) << " this->pub1 did not publish!";
   ret = rcl_publish(&this->pub2, &this->pub2_msg, nullptr);
   EXPECT_EQ(RCL_RET_OK, ret) << " this->pub2 did not publish!";
 
-/*
+
   // wait until messages are received
   bool success = false;
   unsigned int tries;
@@ -1108,13 +1110,13 @@ TEST_F(TestDefaultExecutor, invocation_type) {
     &this->sub2, &this->context, max_tries, timeout_ns, &tries,
     &success);
   ASSERT_TRUE(success);
-*/
+
   // initialize result variables
   _cb1_cnt = 0;
   _cb2_cnt = 0;
 
   // running the executor
-  std::this_thread::sleep_for(rclc_test_sleep_time);
+  // std::this_thread::sleep_for(rclc_test_sleep_time);
 
   ret = rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
   if ((ret == RCL_RET_OK) || (ret == RCL_RET_TIMEOUT)) {
@@ -1123,6 +1125,9 @@ TEST_F(TestDefaultExecutor, invocation_type) {
     // any other error
     EXPECT_EQ(RCL_RET_OK, ret) << "spin_some error";
   }
+  // check total number of received messages
+  EXPECT_EQ(_cb1_cnt, (unsigned int) 1) << "cb1 msg does not match";
+  EXPECT_EQ(_cb2_cnt, (unsigned int) 1) << "cb2 msg does not match";
 
   uint64_t reduced_timeout_ns = 1000000;  // 1ms
   ret = rclc_executor_spin_some(&executor, reduced_timeout_ns);

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -1500,12 +1500,15 @@ TEST_F(TestDefaultExecutor, trigger_one) {
   rcutils_reset_error();
   // ------------------------- test case setup ---------------------------------------------
 
+const std::chrono::milliseconds ci_job_time =
+  std::chrono::milliseconds(1000);
+
   // first round
   _results_callback_init();
   this->pub1_msg.data = 3;
   rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
   EXPECT_EQ(RCL_RET_OK, rc) << " pub1 did not publish!";
-  std::this_thread::sleep_for(rclc_test_sleep_time);
+  std::this_thread::sleep_for(rclc_test_sleep_time+ci_job_time);
   rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
   EXPECT_EQ(_cb1_int_value, (unsigned int) 3) << " expected: A called";
   EXPECT_EQ(_cb2_int_value, (unsigned int) 0) << " expected: B not called";
@@ -1515,7 +1518,7 @@ TEST_F(TestDefaultExecutor, trigger_one) {
   this->pub2_msg.data = 7;
   rc = rcl_publish(&this->pub2, &this->pub2_msg, nullptr);
   EXPECT_EQ(RCL_RET_OK, rc) << " pub2 did not publish!";
-  std::this_thread::sleep_for(rclc_test_sleep_time);
+  std::this_thread::sleep_for(rclc_test_sleep_time+ci_job_time);
   rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
   EXPECT_EQ(_cb1_int_value, (unsigned int) 3) << " expected: A not called";
   EXPECT_EQ(_cb2_int_value, (unsigned int) 0) << " expected: B not called";
@@ -1526,7 +1529,7 @@ TEST_F(TestDefaultExecutor, trigger_one) {
   this->pub1_msg.data = 11;
   rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
   EXPECT_EQ(RCL_RET_OK, rc) << " pub1 did not publish!";
-  std::this_thread::sleep_for(rclc_test_sleep_time);
+  std::this_thread::sleep_for(rclc_test_sleep_time+ci_job_time);
   rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
   EXPECT_EQ(_cb1_int_value, (unsigned int) 11) << " expected: A called";
   EXPECT_EQ(_cb2_int_value, (unsigned int) 7) << " expected: B called";

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -108,6 +108,7 @@ _results_callback_init()
 {
   _results_callback_counters_init();
   _results_callback_values_init();
+  _executor_results_init();
 }
 
 static
@@ -216,6 +217,7 @@ _executor_results_compare(unsigned int * array)
     if (msg == NULL) { \
       printf("Test CB " #NUM ": msg is NULL\n"); \
     } else { \
+      printf("callback_" #NUM " was called\n"); \
       _cb ## NUM ## _int_value = msg->data; \
     } \
     _cb ## NUM ## _cnt++; \

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -249,7 +249,7 @@ void int32_callback4(const void * msgin)
     if (rc != RCL_RET_OK) {
       printf("Error in int32_callback4: could not publish!\n");
     }
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
   }
 }
 

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -250,7 +250,7 @@ void int32_callback4(const void * msgin)
       printf("Error in int32_callback4: could not publish!\n");
     }
     printf("cb4: published %d\n", _pub_int_msg_ptr->data);
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10000)); // 10s
   }
 }
 

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -1135,10 +1135,10 @@ TEST_F(TestDefaultExecutor, invocation_type) {
   // check total number of received messages
   EXPECT_EQ(_cb1_cnt, (unsigned int) 2) << "cb1 msg does not match";
   EXPECT_EQ(_cb2_cnt, (unsigned int) 1) << "cb2 msg does not match";
-  
+
   // tear down
-  rc = rclc_executor_fini(&executor);
-  EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
+  ret = rclc_executor_fini(&executor);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 }
 
 TEST_F(TestDefaultExecutor, update_wait_set) {
@@ -1253,8 +1253,8 @@ TEST_F(TestDefaultExecutor, update_wait_set) {
   EXPECT_EQ((unsigned int)2, _cb2_int_value);
 
   // tear down
-  rc = rclc_executor_fini(&executor);
-  EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
+  ret = rclc_executor_fini(&executor);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 }
 
 

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -104,6 +104,18 @@ _results_callback_values_init()
 
 static
 void
+_executor_results_init(void)
+{
+  for (unsigned int i = 0; i < TC_SPIN_SOME_MAX_MSGS; i++) {
+    _executor_results[i] = 0;
+  }
+  _executor_results_i = 0;
+
+  _results_callback_counters_init();
+}
+
+static
+void
 _results_callback_init()
 {
   _results_callback_counters_init();
@@ -131,17 +143,6 @@ _results_callback_num_received()
   return _cb1_cnt + _cb2_cnt + _cb3_cnt;
 }
 
-static
-void
-_executor_results_init(void)
-{
-  for (unsigned int i = 0; i < TC_SPIN_SOME_MAX_MSGS; i++) {
-    _executor_results[i] = 0;
-  }
-  _executor_results_i = 0;
-
-  _results_callback_counters_init();
-}
 
 /// preserves the order of received data
 /// message values are stored in an array (left to right)
@@ -252,7 +253,7 @@ void int32_callback4(const void * msgin)
       printf("Error in int32_callback4: could not publish!\n");
     }
     printf("cb4: published %d\n", _pub_int_msg_ptr->data);
-    std::this_thread::sleep_for(std::chrono::milliseconds(10000)); // 10s
+    std::this_thread::sleep_for(std::chrono::milliseconds(10000));  // 10s
   }
 }
 

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -1501,7 +1501,7 @@ TEST_F(TestDefaultExecutor, trigger_one) {
   // ------------------------- test case setup ---------------------------------------------
 
   const std::chrono::milliseconds ci_job_time =
-    std::chrono::milliseconds(1000);
+    std::chrono::milliseconds(3000);
 
   // first round
   _results_callback_init();

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -77,7 +77,7 @@ static unsigned int gc1_cnt = 0;
 
 // sleep time beween publish and receive in DDS middleware
 // to allow enough time on CI jobs (in milliseconds)
-#define RCLC_UNIT_TEST_SLEEP_TIME_MS 500
+#define RCLC_UNIT_TEST_SLEEP_TIME_MS 1000
 const std::chrono::milliseconds rclc_test_sleep_time =
   std::chrono::milliseconds(RCLC_UNIT_TEST_SLEEP_TIME_MS);
 
@@ -253,7 +253,7 @@ void int32_callback4(const void * msgin)
       printf("Error in int32_callback4: could not publish!\n");
     }
     printf("cb4: published %d\n", _pub_int_msg_ptr->data);
-    std::this_thread::sleep_for(std::chrono::milliseconds(1000));  // 1s
+    std::this_thread::sleep_for(std::chrono::milliseconds(2000));  // 2s
   }
 }
 

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -1525,6 +1525,7 @@ TEST_F(TestDefaultExecutor, trigger_one) {
   _results_callback_init();
   this->pub1_msg.data = 3;
   rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
+  printf("pub1 3\n");
   EXPECT_EQ(RCL_RET_OK, rc) << " pub1 did not publish!";
   std::this_thread::sleep_for(rclc_test_sleep_time + ci_job_time);
   rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
@@ -1533,8 +1534,9 @@ TEST_F(TestDefaultExecutor, trigger_one) {
   EXPECT_EQ(_cb1_cnt, (unsigned int) 1);
   EXPECT_EQ(_cb2_cnt, (unsigned int) 0);
   // second round
-  this->pub2_msg.data = 7;
+  this->pub2_msg.data = 787;
   rc = rcl_publish(&this->pub2, &this->pub2_msg, nullptr);
+  printf("pub2 787\n");
   EXPECT_EQ(RCL_RET_OK, rc) << " pub2 did not publish!";
   std::this_thread::sleep_for(rclc_test_sleep_time + ci_job_time);
   rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
@@ -1546,11 +1548,12 @@ TEST_F(TestDefaultExecutor, trigger_one) {
   // third round
   this->pub1_msg.data = 11;
   rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
+  printf("pub1 11\n");
   EXPECT_EQ(RCL_RET_OK, rc) << " pub1 did not publish!";
   std::this_thread::sleep_for(rclc_test_sleep_time + ci_job_time);
   rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
   EXPECT_EQ(_cb1_int_value, (unsigned int) 11) << " expected: A called";
-  EXPECT_EQ(_cb2_int_value, (unsigned int) 7) << " expected: B called";
+  EXPECT_EQ(_cb2_int_value, (unsigned int) 787) << " expected: B called";
   EXPECT_EQ(_cb1_cnt, (unsigned int) 2);
   EXPECT_EQ(_cb2_cnt, (unsigned int) 1);
 
@@ -1687,6 +1690,7 @@ TEST_F(TestDefaultExecutor, trigger_all) {
   _executor_results_init();
   this->pub1_msg.data = 3;
   rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
+  printf("published pub1 3\n");
   EXPECT_EQ(RCL_RET_OK, rc) << " pub1 did not publish!";
   std::this_thread::sleep_for(rclc_test_sleep_time);
   rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
@@ -1695,13 +1699,14 @@ TEST_F(TestDefaultExecutor, trigger_all) {
   EXPECT_EQ(_cb1_cnt, (unsigned int) 0);
   EXPECT_EQ(_cb2_cnt, (unsigned int) 0);
   // second round
-  this->pub2_msg.data = 7;
+  this->pub2_msg.data = 76;
   rc = rcl_publish(&this->pub2, &this->pub2_msg, nullptr);
   EXPECT_EQ(RCL_RET_OK, rc) << " pub2 did not publish!";
+  printf("published pub2 76\n");
   std::this_thread::sleep_for(rclc_test_sleep_time);
   rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
   EXPECT_EQ(_cb1_int_value, (unsigned int) 3) << " expected: A called";
-  EXPECT_EQ(_cb2_int_value, (unsigned int) 7) << " expected: B called";
+  EXPECT_EQ(_cb2_int_value, (unsigned int) 76) << " expected: B called";
   EXPECT_EQ(_cb1_cnt, (unsigned int) 1);
   EXPECT_EQ(_cb2_cnt, (unsigned int) 1);
 
@@ -1710,6 +1715,7 @@ TEST_F(TestDefaultExecutor, trigger_all) {
   _cb1_int_value = 0;
   _cb2_int_value = 0;
   rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
+  printf("published pub1 11\n");
   EXPECT_EQ(RCL_RET_OK, rc) << " pub1 did not publish!";
   std::this_thread::sleep_for(rclc_test_sleep_time);
   rclc_executor_spin_some(&executor, rclc_test_timeout_ns);

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -82,7 +82,7 @@ const std::chrono::milliseconds rclc_test_sleep_time =
   std::chrono::milliseconds(RCLC_UNIT_TEST_SLEEP_TIME_MS);
 
 // timeout for rcl_wait() when calling spin_some API of executor
-const uint64_t rclc_test_timeout_ns = 1000000000;  // 1s
+const uint64_t rclc_test_timeout_ns = 10000000000;  // 10s
 
 static
 void
@@ -1500,15 +1500,15 @@ TEST_F(TestDefaultExecutor, trigger_one) {
   rcutils_reset_error();
   // ------------------------- test case setup ---------------------------------------------
 
-const std::chrono::milliseconds ci_job_time =
-  std::chrono::milliseconds(1000);
+  const std::chrono::milliseconds ci_job_time =
+    std::chrono::milliseconds(1000);
 
   // first round
   _results_callback_init();
   this->pub1_msg.data = 3;
   rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
   EXPECT_EQ(RCL_RET_OK, rc) << " pub1 did not publish!";
-  std::this_thread::sleep_for(rclc_test_sleep_time+ci_job_time);
+  std::this_thread::sleep_for(rclc_test_sleep_time + ci_job_time);
   rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
   EXPECT_EQ(_cb1_int_value, (unsigned int) 3) << " expected: A called";
   EXPECT_EQ(_cb2_int_value, (unsigned int) 0) << " expected: B not called";
@@ -1518,7 +1518,7 @@ const std::chrono::milliseconds ci_job_time =
   this->pub2_msg.data = 7;
   rc = rcl_publish(&this->pub2, &this->pub2_msg, nullptr);
   EXPECT_EQ(RCL_RET_OK, rc) << " pub2 did not publish!";
-  std::this_thread::sleep_for(rclc_test_sleep_time+ci_job_time);
+  std::this_thread::sleep_for(rclc_test_sleep_time + ci_job_time);
   rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
   EXPECT_EQ(_cb1_int_value, (unsigned int) 3) << " expected: A not called";
   EXPECT_EQ(_cb2_int_value, (unsigned int) 0) << " expected: B not called";
@@ -1529,7 +1529,7 @@ const std::chrono::milliseconds ci_job_time =
   this->pub1_msg.data = 11;
   rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
   EXPECT_EQ(RCL_RET_OK, rc) << " pub1 did not publish!";
-  std::this_thread::sleep_for(rclc_test_sleep_time+ci_job_time);
+  std::this_thread::sleep_for(rclc_test_sleep_time + ci_job_time);
   rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
   EXPECT_EQ(_cb1_int_value, (unsigned int) 11) << " expected: A called";
   EXPECT_EQ(_cb2_int_value, (unsigned int) 7) << " expected: B called";

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -1535,6 +1535,7 @@ TEST_F(TestDefaultExecutor, trigger_one) {
   EXPECT_EQ(_cb2_cnt, (unsigned int) 0);
   // second round
   this->pub2_msg.data = 787;
+  std::this_thread::sleep_for(rclc_test_sleep_time + ci_job_time);
   rc = rcl_publish(&this->pub2, &this->pub2_msg, nullptr);
   printf("pub2 787\n");
   EXPECT_EQ(RCL_RET_OK, rc) << " pub2 did not publish!";

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -218,7 +218,6 @@ _executor_results_compare(unsigned int * array)
     if (msg == NULL) { \
       printf("Test CB " #NUM ": msg is NULL\n"); \
     } else { \
-      printf("callback_" #NUM " received %d\n", msg->data); \
       _cb ## NUM ## _int_value = msg->data; \
     } \
     _cb ## NUM ## _cnt++; \
@@ -252,7 +251,6 @@ void int32_callback4(const void * msgin)
     if (rc != RCL_RET_OK) {
       printf("Error in int32_callback4: could not publish!\n");
     }
-    printf("cb4: published %d\n", _pub_int_msg_ptr->data);
     std::this_thread::sleep_for(std::chrono::milliseconds(2000));  // 2s
   }
 }
@@ -265,7 +263,6 @@ void int32_callback5(const void * msgin)
   if (msg == NULL) {
     printf("(int32_callback5): msg is NULL\n");
   } else {
-    printf("cb5 msg: %d\n", msg->data);
     _cb5_int_value = msg->data;
   }
 }
@@ -1530,7 +1527,6 @@ TEST_F(TestDefaultExecutor, trigger_one) {
   _results_callback_init();
   this->pub1_msg.data = 3;
   rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
-  printf("pub1 3\n");
   EXPECT_EQ(RCL_RET_OK, rc) << " pub1 did not publish!";
   std::this_thread::sleep_for(ci_job_time);
   rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
@@ -1542,7 +1538,6 @@ TEST_F(TestDefaultExecutor, trigger_one) {
   this->pub2_msg.data = 787;
   std::this_thread::sleep_for(ci_job_time);
   rc = rcl_publish(&this->pub2, &this->pub2_msg, nullptr);
-  printf("pub2 787\n");
   EXPECT_EQ(RCL_RET_OK, rc) << " pub2 did not publish!";
   std::this_thread::sleep_for(ci_job_time);
   rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
@@ -1555,7 +1550,6 @@ TEST_F(TestDefaultExecutor, trigger_one) {
   this->pub1_msg.data = 11;
   std::this_thread::sleep_for(ci_job_time);
   rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
-  printf("pub1 11\n");
   EXPECT_EQ(RCL_RET_OK, rc) << " pub1 did not publish!";
   std::this_thread::sleep_for(rclc_test_sleep_time + ci_job_time);
   rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
@@ -1697,7 +1691,6 @@ TEST_F(TestDefaultExecutor, trigger_all) {
   _executor_results_init();
   this->pub1_msg.data = 3;
   rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
-  printf("published pub1 3\n");
   EXPECT_EQ(RCL_RET_OK, rc) << " pub1 did not publish!";
   std::this_thread::sleep_for(rclc_test_sleep_time);
   rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
@@ -1709,7 +1702,6 @@ TEST_F(TestDefaultExecutor, trigger_all) {
   this->pub2_msg.data = 76;
   rc = rcl_publish(&this->pub2, &this->pub2_msg, nullptr);
   EXPECT_EQ(RCL_RET_OK, rc) << " pub2 did not publish!";
-  printf("published pub2 76\n");
   std::this_thread::sleep_for(rclc_test_sleep_time);
   rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
   EXPECT_EQ(_cb1_int_value, (unsigned int) 3) << " expected: A called";
@@ -1722,7 +1714,6 @@ TEST_F(TestDefaultExecutor, trigger_all) {
   _cb1_int_value = 0;
   _cb2_int_value = 0;
   rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
-  printf("published pub1 11\n");
   EXPECT_EQ(RCL_RET_OK, rc) << " pub1 did not publish!";
   std::this_thread::sleep_for(rclc_test_sleep_time);
   rclc_executor_spin_some(&executor, rclc_test_timeout_ns);

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -1498,8 +1498,8 @@ TEST_F(TestDefaultExecutor, trigger_one) {
   EXPECT_EQ(_cb2_cnt, (unsigned int) 0);
   // second round
   this->pub2_msg.data = 7;
-  rc = rcl_publish(&this->pub2, &this->pub2_msg, nullptr);
-  EXPECT_EQ(RCL_RET_OK, rc) << " pub2 did not publish!";
+  //rc = rcl_publish(&this->pub2, &this->pub2_msg, nullptr);
+  //EXPECT_EQ(RCL_RET_OK, rc) << " pub2 did not publish!";
   std::this_thread::sleep_for(rclc_test_sleep_time);
   rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
   EXPECT_EQ(_cb1_int_value, (unsigned int) 3) << " expected: A not called";

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -250,7 +250,7 @@ void int32_callback4(const void * msgin)
       printf("Error in int32_callback4: could not publish!\n");
     }
     printf("cb4: published %d\n", _pub_int_msg_ptr->data);
-    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
   }
 }
 
@@ -1319,6 +1319,9 @@ TEST_F(TestDefaultExecutor, semantics_RCLCPP) {
     &int32_callback4, ON_NEW_DATA);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   rcutils_reset_error();
+
+  subscription2_int_msg.data = 77;
+
   rc = rclc_executor_add_subscription(
     &executor, &subscription2, &subscription2_int_msg,
     &int32_callback5, ON_NEW_DATA);

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -77,7 +77,7 @@ static unsigned int gc1_cnt = 0;
 
 // sleep time beween publish and receive in DDS middleware
 // to allow enough time on CI jobs (in milliseconds)
-#define RCLC_UNIT_TEST_SLEEP_TIME_MS 100
+#define RCLC_UNIT_TEST_SLEEP_TIME_MS 1000
 const std::chrono::milliseconds rclc_test_sleep_time =
   std::chrono::milliseconds(RCLC_UNIT_TEST_SLEEP_TIME_MS);
 
@@ -1498,8 +1498,8 @@ TEST_F(TestDefaultExecutor, trigger_one) {
   EXPECT_EQ(_cb2_cnt, (unsigned int) 0);
   // second round
   this->pub2_msg.data = 7;
-  //rc = rcl_publish(&this->pub2, &this->pub2_msg, nullptr);
-  //EXPECT_EQ(RCL_RET_OK, rc) << " pub2 did not publish!";
+  rc = rcl_publish(&this->pub2, &this->pub2_msg, nullptr);
+  EXPECT_EQ(RCL_RET_OK, rc) << " pub2 did not publish!";
   std::this_thread::sleep_for(rclc_test_sleep_time);
   rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
   EXPECT_EQ(_cb1_int_value, (unsigned int) 3) << " expected: A not called";

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -1135,6 +1135,10 @@ TEST_F(TestDefaultExecutor, invocation_type) {
   // check total number of received messages
   EXPECT_EQ(_cb1_cnt, (unsigned int) 2) << "cb1 msg does not match";
   EXPECT_EQ(_cb2_cnt, (unsigned int) 1) << "cb2 msg does not match";
+  
+  // tear down
+  rc = rclc_executor_fini(&executor);
+  EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
 }
 
 TEST_F(TestDefaultExecutor, update_wait_set) {
@@ -1247,6 +1251,10 @@ TEST_F(TestDefaultExecutor, update_wait_set) {
   EXPECT_EQ((unsigned int)1, _cb2_cnt);
   EXPECT_EQ((unsigned int)1, _cb1_int_value);
   EXPECT_EQ((unsigned int)2, _cb2_int_value);
+
+  // tear down
+  rc = rclc_executor_fini(&executor);
+  EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
 }
 
 
@@ -1282,6 +1290,10 @@ TEST_F(TestDefaultExecutor, spin_period) {
   uint64_t delta = 5000000;  // 5 ms interval
   EXPECT_LE(duration, spin_period + delta);
   EXPECT_LE(spin_period - delta, duration);
+
+  // tear down
+  rc = rclc_executor_fini(&executor);
+  EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
 }
 
 TEST_F(TestDefaultExecutor, semantics_RCLCPP) {
@@ -1364,6 +1376,9 @@ TEST_F(TestDefaultExecutor, semantics_RCLCPP) {
 
   // clean-up
   rc = rcl_subscription_fini(&subscription2, &this->node);
+  // tear down
+  rc = rclc_executor_fini(&executor);
+  EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
 }
 
 TEST_F(TestDefaultExecutor, semantics_LET) {
@@ -1450,6 +1465,9 @@ TEST_F(TestDefaultExecutor, semantics_LET) {
 
   // clean-up
   rc = rcl_subscription_fini(&subscription2, &this->node);
+  // tear down
+  rc = rclc_executor_fini(&executor);
+  EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
 }
 
 TEST_F(TestDefaultExecutor, trigger_one) {
@@ -1535,6 +1553,10 @@ TEST_F(TestDefaultExecutor, trigger_one) {
   EXPECT_EQ(_cb2_int_value, (unsigned int) 7) << " expected: B called";
   EXPECT_EQ(_cb1_cnt, (unsigned int) 2);
   EXPECT_EQ(_cb2_cnt, (unsigned int) 1);
+
+  // tear down
+  rc = rclc_executor_fini(&executor);
+  EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
 }
 
 TEST_F(TestDefaultExecutor, trigger_any) {
@@ -1613,6 +1635,10 @@ TEST_F(TestDefaultExecutor, trigger_any) {
   EXPECT_EQ(_cb2_int_value, (unsigned int) 0) << " expected: B not called";
   EXPECT_EQ(_cb1_cnt, (unsigned int) 2);
   EXPECT_EQ(_cb2_cnt, (unsigned int) 1);
+
+  // tear down
+  rc = rclc_executor_fini(&executor);
+  EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
 }
 
 TEST_F(TestDefaultExecutor, trigger_all) {
@@ -1691,6 +1717,10 @@ TEST_F(TestDefaultExecutor, trigger_all) {
   EXPECT_EQ(_cb2_int_value, (unsigned int) 0) << " expected: B not called";
   EXPECT_EQ(_cb1_cnt, (unsigned int) 1);
   EXPECT_EQ(_cb2_cnt, (unsigned int) 1);
+
+  // tear down
+  rc = rclc_executor_fini(&executor);
+  EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
 }
 
 TEST_F(TestDefaultExecutor, trigger_always) {
@@ -1762,6 +1792,10 @@ TEST_F(TestDefaultExecutor, trigger_always) {
   EXPECT_EQ(_cb2_int_value, (unsigned int) 7) << " expected: B called";
   EXPECT_EQ(_cb1_cnt, (unsigned int) 1);
   EXPECT_EQ(_cb2_cnt, (unsigned int) 3);
+
+  // tear down
+  rc = rclc_executor_fini(&executor);
+  EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
 }
 
 TEST_F(TestDefaultExecutor, executor_test_service) {


### PR DESCRIPTION
rclc executor unit_test semantics_RCLCPP
- Dashing: local colcon_test with ROS 2 Dashing passes
- Foxy timing issues with trigger_always condition
