### PR TITLE
Adds service callback with service context

### DIFF
--- a/rclc/include/rclc/executor_handle.h
+++ b/rclc/include/rclc/executor_handle.h
@@ -49,7 +49,8 @@ typedef enum
 {
   CB_UNDEFINED,
   CB_WITHOUT_REQUEST_ID,
-  CB_WITH_REQUEST_ID
+  CB_WITH_REQUEST_ID,
+  CB_WITH_CONTEXT,
 } rclc_executor_handle_callback_type_t;
 
 
@@ -66,6 +67,12 @@ typedef void (* rclc_service_callback_t)(const void *, void *);
 /// - request id
 /// - response message
 typedef void (* rclc_service_callback_with_request_id_t)(const void *, rmw_request_id_t *, void *);
+
+/// Type definition for client callback function
+/// - request message
+/// - response message
+/// - additional service context
+typedef void (* rclc_service_callback_with_context_t)(const void *, void *, void *);
 
 /// Type definition for client callback function
 /// - response message
@@ -106,6 +113,9 @@ typedef struct
   /// only for service - ptr to response message
   void * data_response_msg;
 
+  /// only for service - ptr to additional service context
+  void * service_context;
+
   // TODO(jst3si) new type to be stored as data for
   //              service/client objects
   //              look at memory allocation for this struct!
@@ -120,6 +130,7 @@ typedef struct
     rclc_callback_t callback;
     rclc_service_callback_t service_callback;
     rclc_service_callback_with_request_id_t service_callback_with_reqid;
+    rclc_service_callback_with_context_t service_callback_with_context;
     rclc_client_callback_t client_callback;
     rclc_client_callback_with_request_id_t client_callback_with_reqid;
     rclc_gc_callback_t gc_callback;

--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -768,6 +768,11 @@ _rclc_execute(rclc_executor_handle_t * handle)
 
       case SERVICE:
         switch (handle->callback_type) {
+          case CB_WITHOUT_REQUEST_ID:
+            handle->service_callback(
+              handle->data,
+              handle->data_response_msg);
+            break;
           case CB_WITH_REQUEST_ID:
             handle->service_callback_with_reqid(
               handle->data,
@@ -780,10 +785,6 @@ _rclc_execute(rclc_executor_handle_t * handle)
               handle->data_response_msg,
               handle->service_context);
             break;
-          default:
-            handle->service_callback(
-              handle->data,
-              handle->data_response_msg);
         }
 
         rc = rcl_send_response(handle->service, &handle->req_id, handle->data_response_msg);
@@ -794,7 +795,9 @@ _rclc_execute(rclc_executor_handle_t * handle)
         break;
 
       case CLIENT:
-        if (handle->callback_type == CB_WITHOUT_REQUEST_ID) {
+        if (handle->callback_type == CB_WITHOUT_REQUEST_ID ||
+          handle->callback_type == CB_WITH_CONTEXT)
+        {
           handle->client_callback(handle->data);
         } else if (handle->callback_type == CB_WITH_REQUEST_ID) {
           handle->client_callback_with_reqid(handle->data, &handle->req_id);

--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -431,6 +431,59 @@ rclc_executor_add_service(
 }
 
 rcl_ret_t
+rclc_executor_add_service_with_context(
+  rclc_executor_t * executor,
+  rcl_service_t * service,
+  void * request_msg,
+  void * response_msg,
+  rclc_service_callback_with_context_t callback,
+  void * context)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(executor, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(service, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(request_msg, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(response_msg, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(callback, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(context, RCL_RET_INVALID_ARGUMENT);  //?
+  rcl_ret_t ret = RCL_RET_OK;
+  // array bound check
+  if (executor->index >= executor->max_handles) {
+    rcl_ret_t ret = RCL_RET_ERROR;
+    RCL_SET_ERROR_MSG("Buffer overflow of 'executor->handles'. Increase 'max_handles'");
+    return ret;
+  }
+
+  // assign data fields
+  executor->handles[executor->index].type = SERVICE;
+  executor->handles[executor->index].service = service;
+  executor->handles[executor->index].data = request_msg;
+  // TODO(jst3si) new type with req and resp message in data field.
+  executor->handles[executor->index].data_response_msg = response_msg;
+  executor->handles[executor->index].service_callback_with_context = callback;
+  executor->handles[executor->index].callback_type = CB_WITH_CONTEXT;
+  executor->handles[executor->index].invocation = ON_NEW_DATA;  // invoce when request came in
+  executor->handles[executor->index].initialized = true;
+  executor->handles[executor->index].service_context = context;
+
+  // increase index of handle array
+  executor->index++;
+
+  // invalidate wait_set so that in next spin_some() call the
+  // 'executor->wait_set' is updated accordingly
+  if (rcl_wait_set_is_valid(&executor->wait_set)) {
+    ret = rcl_wait_set_fini(&executor->wait_set);
+    if (RCL_RET_OK != ret) {
+      RCL_SET_ERROR_MSG("Could not reset wait_set in rclc_executor_add_service function.");
+      return ret;
+    }
+  }
+
+  executor->info.number_of_services++;
+  RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Added a service.");
+  return ret;
+}
+
+rcl_ret_t
 rclc_executor_add_service_with_request_id(
   rclc_executor_t * executor,
   rcl_service_t * service,
@@ -714,13 +767,25 @@ _rclc_execute(rclc_executor_handle_t * handle)
         break;
 
       case SERVICE:
-        if (handle->callback_type == CB_WITHOUT_REQUEST_ID) {
-          handle->service_callback(handle->data, handle->data_response_msg);
-        } else if (handle->callback_type == CB_WITH_REQUEST_ID) {
-          handle->service_callback_with_reqid(
-            handle->data, &handle->req_id,
-            handle->data_response_msg);
+        switch (handle->callback_type) {
+          case CB_WITH_REQUEST_ID:
+            handle->service_callback_with_reqid(
+              handle->data,
+              &handle->req_id,
+              handle->data_response_msg);
+            break;
+          case CB_WITH_CONTEXT:
+            handle->service_callback_with_context(
+              handle->data,
+              handle->data_response_msg,
+              handle->service_context);
+            break;
+          default:
+            handle->service_callback(
+              handle->data,
+              handle->data_response_msg);
         }
+
         rc = rcl_send_response(handle->service, &handle->req_id, handle->data_response_msg);
         if (rc != RCL_RET_OK) {
           PRINT_RCLC_ERROR(rclc_execute, rcl_send_response);

--- a/rclc/src/rclc/executor_handle.c
+++ b/rclc/src/rclc/executor_handle.c
@@ -48,6 +48,7 @@ rclc_executor_handle_init(
 
   handle->data = NULL;
   handle->data_response_msg = NULL;
+  handle->service_context = NULL;
 
   handle->callback = NULL;
   // because of union structure:


### PR DESCRIPTION
Adds an additional callback type and handling that allows passing
additional service context (void *) to a service callback.

https://github.com/ros2/rclc/issues/35