### PR TITLE
Add sleep functionality

### DIFF
--- a/rclc/CMakeLists.txt
+++ b/rclc/CMakeLists.txt
@@ -57,6 +57,7 @@ add_library(${PROJECT_NAME}
   src/rclc/node.c
   src/rclc/executor_handle.c
   src/rclc/executor.c
+  src/rclc/sleep.c
 )
 if("${rcl_VERSION}" VERSION_LESS "1.0.0")
   target_sources(${PROJECT_NAME} PRIVATE src/rclc/rcl_wait_set_is_valid_backport.c)

--- a/rclc/include/rclc/executor.h
+++ b/rclc/include/rclc/executor.h
@@ -29,15 +29,8 @@ extern "C"
 
 #include "rclc/executor_handle.h"
 #include "rclc/types.h"
+#include "rclc/sleep.h"
 #include "rclc/visibility_control.h"
-
-#ifdef WIN32
-#include <Windows.h>
-#define rclc_sleep_ms(x) Sleep(x)
-#else
-#include <unistd.h>
-#define rclc_sleep_ms(x) usleep(x * 1000)
-#endif
 
 /*! \file executor.h
     \brief The RCLC-Executor provides an Executor based on RCL in which all callbacks are

--- a/rclc/include/rclc/sleep.h
+++ b/rclc/include/rclc/sleep.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2019 - for information on the respective copyright owner
+// see the NOTICE file and/or the repository https://github.com/ros2/rclc.
+// Copyright 2014 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef RCLC__SLEEP_H_
+#define RCLC__SLEEP_H_
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+#include "rclc/visibility_control.h"
+
+/**
+ *  Waits for milliseconds.
+ *
+ *  * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] ms milliseconds to wait
+ */
+RCLC_PUBLIC
+void
+rclc_sleep_ms(
+  unsigned int ms);
+
+#if __cplusplus
+}
+#endif
+
+#endif  // RCLC__SLEEP_H_

--- a/rclc/src/rclc/sleep.c
+++ b/rclc/src/rclc/sleep.c
@@ -1,0 +1,34 @@
+// Copyright (c) 2019 - for information on the respective copyright owner
+// see the NOTICE file and/or the repository https://github.com/ros2/rclc.
+// Copyright 2014 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rclc/sleep.h"
+
+#ifdef WIN32
+#include <Windows.h>
+#else
+#include <unistd.h>
+#endif
+
+void
+rclc_sleep_ms(
+  unsigned int ms)
+{
+#ifdef WIN32
+  Sleep(ms);
+#else
+  usleep(ms * 1000);
+#endif
+}


### PR DESCRIPTION
I have had some incompatibility problems because we are forcing users to `#include <unistd.h>` in `executor.h` and in some cross-compiled environments, this POSIX include is causing incompatibility errors.

Are you ok with including this functionality as part of the RCLC library?