### PR TITLE
Backport: Use executor allocator in spin

### DIFF
--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -934,7 +934,9 @@ rclc_executor_spin_some(rclc_executor_t * executor, const uint64_t timeout_ns)
       executor->info.number_of_guard_conditions, executor->info.number_of_timers,
       executor->info.number_of_clients, executor->info.number_of_services,
       executor->info.number_of_events,
-      executor->context, rcl_get_default_allocator());
+      executor->context,
+      *executor->allocator);
+
     if (rc != RCL_RET_OK) {
       PRINT_RCLC_ERROR(rclc_executor_spin_some, rcl_wait_set_init);
       return rc;


### PR DESCRIPTION
* Use executor allocator in spin

Signed-off-by: Jan Staschulat <jan.staschulat@de.bosch.com>

* ran ament_uncrustify --reformat

Signed-off-by: Jan Staschulat <jan.staschulat@de.bosch.com>

Co-authored-by: Jan Staschulat <jan.staschulat@de.bosch.com>
