### PR TITLE
Prepare bloom release 1.0.1 for Rolling

### DIFF
--- a/rclc/CHANGELOG.rst
+++ b/rclc/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog for package rclc
 ------------------
 * Windows port
 * Compatibility sleep function (Windows, POSIX-OS)
-* Minor bug fixes
+* Fixed RCL lifecycle API change for Rolling
 
 1.0.0 (2021-03-04)
 ------------------

--- a/rclc/CHANGELOG.rst
+++ b/rclc/CHANGELOG.rst
@@ -1,6 +1,13 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package rclc
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1.0.1 (2021-03-29)
+------------------
+* Windows port
+* Compatibility sleep function (Windows, POSIX-OS)
+* Minor bug fixes
+
 1.0.0 (2021-03-04)
 ------------------
 * service callbacks with context

--- a/rclc/package.xml
+++ b/rclc/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>rclc</name>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <description>The ROS client library in C.</description>
   <maintainer email="jan.staschulat@de.bosch.com">Jan Staschulat</maintainer>
   <maintainer email="pablogarrido@eprosima.com">Pablo Garrido</maintainer>

--- a/rclc_examples/CHANGELOG.rst
+++ b/rclc_examples/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package rclc_examples
 ------------------
 * Windows port
 * Compatibility sleep function (Windows, POSIX-OS)
-* Minor bug fixes
+* Fixed RCL lifecycle API change for Rolling
 
 1.0.0 (2021-03-04)
 ------------------

--- a/rclc_examples/CHANGELOG.rst
+++ b/rclc_examples/CHANGELOG.rst
@@ -1,6 +1,12 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package rclc_examples
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+1.0.1 (2021-03-29)
+------------------
+* Windows port
+* Compatibility sleep function (Windows, POSIX-OS)
+* Minor bug fixes
+
 1.0.0 (2021-03-04)
 ------------------
 * Updated version

--- a/rclc_examples/package.xml
+++ b/rclc_examples/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>rclc_examples</name>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <description>Example of using rclc_executor</description>
   <maintainer email="jan.staschulat@de.bosch.com">Jan Staschulat</maintainer>
 

--- a/rclc_lifecycle/CHANGELOG.rst
+++ b/rclc_lifecycle/CHANGELOG.rst
@@ -1,6 +1,12 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package rclc_lifecycle
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+1.0.1 (2021-03-29)
+------------------
+* Windows port
+* Compatibility sleep function (Windows, POSIX-OS)
+* Minor bug fixes
+
 1.0.0 (2021-03-04)
 ------------------
 * Updated version

--- a/rclc_lifecycle/CHANGELOG.rst
+++ b/rclc_lifecycle/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package rclc_lifecycle
 ------------------
 * Windows port
 * Compatibility sleep function (Windows, POSIX-OS)
-* Minor bug fixes
+* Fixed RCL lifecycle API change for Rolling
 
 1.0.0 (2021-03-04)
 ------------------

--- a/rclc_lifecycle/package.xml
+++ b/rclc_lifecycle/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rclc_lifecycle</name>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <description>rclc lifecycle convenience methods.</description>
   <maintainer email="jan.staschulat@de.bosch.com">Jan Staschulat</maintainer>
 


### PR DESCRIPTION
Current bloom release for Rolling fails because version 1.0.0 is used. Changes because of RCL API are not considered. New bloom release necessary.