### PR TITLE
add Subscription with context pointer

### DIFF
--- a/rclc/include/rclc/executor.h
+++ b/rclc/include/rclc/executor.h
@@ -452,6 +452,142 @@ rclc_executor_add_guard_condition(
   rcl_guard_condition_t * gc,
   rclc_gc_callback_t callback);
 
+
+
+/**
+ *  Removes a subscription from an executor.
+ * * An error is returned if {@link rclc_executor_t.handles} array is empty.
+ * * An error is returned if subscription is not found in {@link rclc_executor_t.handles}.
+ * * The total number_of_subscriptions field of {@link rclc_executor_t.info}
+ *   is decremented by one.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param [inout] executor pointer to initialized executor
+ * \param [in] subscription pointer to an allocated and initialized subscription previously added to executor
+ * \return `RCL_RET_OK` if add-operation was successful
+ * \return `RCL_RET_INVALID_ARGUMENT` if any parameter is a null pointer
+ * \return `RCL_RET_ERROR` if any other error occured
+ */
+rcl_ret_t
+rclc_executor_remove_subscription(
+  rclc_executor_t * executor,
+  const rcl_subscription_t * subscription);
+
+
+/**
+ *  Removes a timer from an executor.
+ * * An error is returned if {@link rclc_executor_t.handles} array is empty.
+ * * An error is returned if timer is not found in {@link rclc_executor_t.handles}.
+ * * The total number_of_timers field of {@link rclc_executor_t.info}
+ *   is incremented by one.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param [inout] executor pointer to initialized executor
+ * \param [in] timer pointer to an allocated and initialized timer previously added to executor
+ * \return `RCL_RET_OK` if add-operation was successful
+ * \return `RCL_RET_INVALID_ARGUMENT` if any parameter is a null pointer
+ * \return `RCL_RET_ERROR` if any other error occured
+ */
+rcl_ret_t
+rclc_executor_remove_timer(
+  rclc_executor_t * executor,
+  const rcl_timer_t * timer);
+
+
+/**
+ *  Removes a client from an executor.
+ * * An error is returned if {@link rclc_executor_t.handles} array is empty.
+ * * An error is returned if client is not found in {@link rclc_executor_t.handles}.
+ * * The total number_of_clients field of {@link rclc_executor_t.info}
+ *   is incremented by one.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param [inout] executor pointer to initialized executor
+ * \param [in] client pointer to an allocated and initialized client previously added to executor
+ * \return `RCL_RET_OK` if add-operation was successful
+ * \return `RCL_RET_INVALID_ARGUMENT` if any parameter is a null pointer
+ * \return `RCL_RET_ERROR` if any other error occured
+ */
+rcl_ret_t
+rclc_executor_remove_client(
+  rclc_executor_t * executor,
+  const rcl_client_t * client);
+
+
+/**
+ *  Removes a service from an executor.
+ * * An error is returned if {@link rclc_executor_t.handles} array is empty.
+ * * An error is returned if service is not found in {@link rclc_executor_t.handles}.
+ * * The total number_of_services field of {@link rclc_executor_t.info}
+ *   is incremented by one.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param [inout] executor pointer to initialized executor
+ * \param [in] service pointer to an allocated and initialized service previously added to executor
+ * \return `RCL_RET_OK` if add-operation was successful
+ * \return `RCL_RET_INVALID_ARGUMENT` if any parameter is a null pointer
+ * \return `RCL_RET_ERROR` if any other error occured
+ */
+rcl_ret_t
+rclc_executor_remove_service(
+  rclc_executor_t * executor,
+  const rcl_service_t * service);
+
+/**
+ *  Removes a guard_condition from an executor.
+ * * An error is returned if {@link rclc_executor_t.handles} array is empty.
+ * * An error is returned if guard_condition is not found in {@link rclc_executor_t.handles}.
+ * * The total number_of_guard_conditions field of {@link rclc_executor_t.info}
+ *   is incremented by one.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param [inout] executor pointer to initialized executor
+ * \param [in] guard_condition pointer to an allocated and initialized guard_condition previously added to executor
+ * \return `RCL_RET_OK` if add-operation was successful
+ * \return `RCL_RET_INVALID_ARGUMENT` if any parameter is a null pointer
+ * \return `RCL_RET_ERROR` if any other error occured
+ */
+rcl_ret_t
+rclc_executor_remove_guard_condition(
+  rclc_executor_t * executor,
+  const rcl_guard_condition_t * guard_condition);
+
+
 /**
  *  The spin-some function checks one-time for new data from the DDS-queue.
  * * the timeout is defined in {@link rclc_executor_t.timeout_ns} and can

--- a/rclc/include/rclc/executor.h
+++ b/rclc/include/rclc/executor.h
@@ -214,6 +214,39 @@ rclc_executor_add_subscription(
   rclc_executor_handle_invocation_t invocation);
 
 /**
+ *  Adds a subscription to an executor.
+ * * An error is returned, if {@link rclc_executor_t.handles} array is full.
+ * * The total number_of_subscriptions field of {@link rclc_executor_t.info}
+ *   is incremented by one.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param [inout] executor pointer to initialized executor
+ * \param [in] subscription pointer to an allocated subscription
+ * \param [in] msg pointer to an allocated message
+ * \param [in] callback    function pointer to a callback
+ * \param [in] context     type-erased ptr to additional callback context
+ * \param [in] invocation  invocation type for the callback (ALWAYS or only ON_NEW_DATA)
+ * \return `RCL_RET_OK` if add-operation was successful
+ * \return `RCL_RET_INVALID_ARGUMENT` if any parameter is a null pointer (NULL context is ignored)
+ * \return `RCL_RET_ERROR` if any other error occured
+ */
+rcl_ret_t
+rclc_executor_add_subscription_with_context(
+  rclc_executor_t * executor,
+  rcl_subscription_t * subscription,
+  void * msg,
+  rclc_subscription_callback_with_context_t callback,
+  void * context,
+  rclc_executor_handle_invocation_t invocation);
+
+/**
  *  Adds a timer to an executor.
  * * An error is returned, if {@link rclc_executor_t.handles} array is full.
  * * The total number_of_timers field of {@link rclc_executor_t.info} is

--- a/rclc/include/rclc/executor_handle.h
+++ b/rclc/include/rclc/executor_handle.h
@@ -57,6 +57,15 @@ typedef enum
 /// Type definition for callback function.
 typedef void (* rclc_callback_t)(const void *);
 
+/// Type definition for subscription callback function
+/// - incoming message
+//typedef void (* rclc_subscription_callback_t)(const void *);
+
+/// Type definition for subscription callback function
+/// - incoming message
+/// - additional callback context
+typedef void (* rclc_subscription_callback_with_context_t)(const void *, void *);
+
 /// Type definition for client callback function
 /// - request message
 /// - response message
@@ -113,8 +122,8 @@ typedef struct
   /// only for service - ptr to response message
   void * data_response_msg;
 
-  /// only for service - ptr to additional service context
-  void * service_context;
+  /// ptr to additional callback context
+  void * callback_context;
 
   // TODO(jst3si) new type to be stored as data for
   //              service/client objects
@@ -128,6 +137,7 @@ typedef struct
   /// Storage for callbacks
   union {
     rclc_callback_t callback;
+    rclc_subscription_callback_with_context_t subscription_callback_with_context;
     rclc_service_callback_t service_callback;
     rclc_service_callback_with_request_id_t service_callback_with_reqid;
     rclc_service_callback_with_context_t service_callback_with_context;

--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -225,6 +225,7 @@ rclc_executor_add_subscription(
   executor->handles[executor->index].subscription = subscription;
   executor->handles[executor->index].data = msg;
   executor->handles[executor->index].callback = callback;
+  executor->handles[executor->index].callback_type = CB_WITHOUT_REQUEST_ID;
   executor->handles[executor->index].invocation = invocation;
   executor->handles[executor->index].initialized = true;
 
@@ -273,6 +274,7 @@ rclc_executor_add_subscription_with_context(
   executor->handles[executor->index].subscription = subscription;
   executor->handles[executor->index].data = msg;
   executor->handles[executor->index].subscription_callback_with_context = callback;
+  executor->handles[executor->index].callback_type = CB_WITH_CONTEXT;
   executor->handles[executor->index].invocation = invocation;
   executor->handles[executor->index].initialized = true;
   executor->handles[executor->index].callback_context = context;

--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -699,7 +699,7 @@ rclc_executor_remove_timer(
   const rcl_timer_t * timer)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(executor, RCL_RET_INVALID_ARGUMENT);
-  RCL_CHECK_ARGUMENT_FOR_NULL(subscription, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(timer, RCL_RET_INVALID_ARGUMENT);
   rcl_ret_t ret = RCL_RET_OK;
 
   for (size_t i = 0; (i < executor->max_handles && executor->handles[i].initialized); i++) {
@@ -792,7 +792,7 @@ rclc_executor_remove_guard_condition(
   
   for (size_t i = 0; (i < executor->max_handles && executor->handles[i].initialized); i++) {
     if(GUARD_CONDITION == executor->handles[i].type){
-      if(guard_condition == executor->handles[i].guard_condition)
+      if(guard_condition == executor->handles[i].gc)
       {
         _rclc_executor_remove_handle(executor, i);
         if (RCL_RET_OK != ret) {

--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -644,9 +644,11 @@ _rclc_executor_remove_handle(rclc_executor_t * executor, size_t handle_index)
     return RCL_RET_ERROR;
   }
 
-  //shorten the list of handles by moving the last handle to the Nth position.
+  //shorten the list of handles without changing the order of remaining handles
   executor->index--;
-  executor->handles[handle_index] = executor->handles[executor->index];
+  for(int i=handle_index; i < executor->index; i++){
+    executor->handles[i] = executor->handles[i+1];
+  }
   ret = rclc_executor_handle_init(&executor->handles[executor->index], executor->max_handles);
 
   //force a refresh of the wait set

--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -247,6 +247,54 @@ rclc_executor_add_subscription(
   return ret;
 }
 
+
+rcl_ret_t
+rclc_executor_add_subscription_with_context(
+  rclc_executor_t * executor,
+  rcl_subscription_t * subscription,
+  void * msg,
+  rclc_subscription_callback_with_context_t callback,
+  void * context,
+  rclc_executor_handle_invocation_t invocation)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(executor, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(subscription, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(msg, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(callback, RCL_RET_INVALID_ARGUMENT);
+  rcl_ret_t ret = RCL_RET_OK;
+  // array bound check
+  if (executor->index >= executor->max_handles) {
+    RCL_SET_ERROR_MSG("Buffer overflow of 'executor->handles'. Increase 'max_handles'");
+    return RCL_RET_ERROR;
+  }
+
+  // assign data fields
+  executor->handles[executor->index].type = SUBSCRIPTION;
+  executor->handles[executor->index].subscription = subscription;
+  executor->handles[executor->index].data = msg;
+  executor->handles[executor->index].callback = callback;
+  executor->handles[executor->index].invocation = invocation;
+  executor->handles[executor->index].initialized = true;
+
+  // increase index of handle array
+  executor->index++;
+
+  // invalidate wait_set so that in next spin_some() call the
+  // 'executor->wait_set' is updated accordingly
+  if (rcl_wait_set_is_valid(&executor->wait_set)) {
+    ret = rcl_wait_set_fini(&executor->wait_set);
+    if (RCL_RET_OK != ret) {
+      RCL_SET_ERROR_MSG("Could not reset wait_set in rclc_executor_add_subscription.");
+      return ret;
+    }
+  }
+
+  executor->info.number_of_subscriptions++;
+
+  RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Added a subscription.");
+  return ret;
+}
+
 rcl_ret_t
 rclc_executor_add_timer(
   rclc_executor_t * executor,
@@ -463,7 +511,7 @@ rclc_executor_add_service_with_context(
   executor->handles[executor->index].callback_type = CB_WITH_CONTEXT;
   executor->handles[executor->index].invocation = ON_NEW_DATA;  // invoce when request came in
   executor->handles[executor->index].initialized = true;
-  executor->handles[executor->index].service_context = context;
+  executor->handles[executor->index].callback_context = context;
 
   // increase index of handle array
   executor->index++;
@@ -751,11 +799,25 @@ _rclc_execute(rclc_executor_handle_t * handle)
   if (invoke_callback) {
     switch (handle->type) {
       case SUBSCRIPTION:
-        if (handle->data_available) {
-          handle->callback(handle->data);
-        } else {
-          handle->callback(NULL);
-        }
+        switch (handle->callback_type) {
+          case CB_WITHOUT_REQUEST_ID:
+            if (handle->data_available) {
+              handle->callback(handle->data);
+            } else {
+              handle->callback(NULL);
+            }
+            break;
+          case CB_WITH_CONTEXT:
+            if (handle->data_available) {
+              handle->subscription_callback_with_context(
+                handle->data,
+                handle->callback_context);
+            } else {
+              handle->subscription_callback_with_context(
+                NULL,
+                handle->callback_context);
+            }
+            break;
         break;
 
       case TIMER:
@@ -783,7 +845,7 @@ _rclc_execute(rclc_executor_handle_t * handle)
             handle->service_callback_with_context(
               handle->data,
               handle->data_response_msg,
-              handle->service_context);
+              handle->callback_context);
             break;
           default:
             PRINT_RCLC_ERROR(rclc_execute, unknown_callback_type);

--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -646,7 +646,7 @@ _rclc_executor_remove_handle(rclc_executor_t * executor, size_t handle_index)
 
   //shorten the list of handles without changing the order of remaining handles
   executor->index--;
-  for(int i=handle_index; i < executor->index; i++){
+  for(size_t i=handle_index; i < executor->index; i++){
     executor->handles[i] = executor->handles[i+1];
   }
   ret = rclc_executor_handle_init(&executor->handles[executor->index], executor->max_handles);

--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -646,12 +646,12 @@ _rclc_executor_remove_handle(rclc_executor_t * executor, size_t handle_index)
 
   //shorten the list of handles without changing the order of remaining handles
   executor->index--;
-  for(size_t i=handle_index; i < executor->index; i++){
+  for(size_t i=handle_index; i < executor->index; i++) {
     executor->handles[i] = executor->handles[i+1];
   }
   ret = rclc_executor_handle_init(&executor->handles[executor->index], executor->max_handles);
 
-  //force a refresh of the wait set
+  // force a refresh of the wait set
   if (rcl_wait_set_is_valid(&executor->wait_set)) {
     ret = rcl_wait_set_fini(&executor->wait_set);
     if (RCL_RET_OK != ret) {
@@ -676,9 +676,8 @@ rclc_executor_remove_subscription(
   rcl_ret_t ret = RCL_RET_OK;
 
   for (size_t i = 0; (i < executor->max_handles && executor->handles[i].initialized); i++) {
-    if(SUBSCRIPTION == executor->handles[i].type){
-      if(subscription == executor->handles[i].subscription)
-      {
+    if(SUBSCRIPTION == executor->handles[i].type) {
+      if(subscription == executor->handles[i].subscription) {
         ret = _rclc_executor_remove_handle(executor, i);
         if (RCL_RET_OK != ret) {
           RCL_SET_ERROR_MSG("Failed to remove handle in rclc_executor_remove_subscription.");
@@ -687,7 +686,6 @@ rclc_executor_remove_subscription(
         executor->info.number_of_subscriptions--;
         RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Removed a subscription.");
         return ret;
-
       }
     }
   }
@@ -705,9 +703,8 @@ rclc_executor_remove_timer(
   rcl_ret_t ret = RCL_RET_OK;
 
   for (size_t i = 0; (i < executor->max_handles && executor->handles[i].initialized); i++) {
-    if(TIMER == executor->handles[i].type){
-      if(timer == executor->handles[i].timer)
-      {
+    if(TIMER == executor->handles[i].type) {
+      if(timer == executor->handles[i].timer) {
         _rclc_executor_remove_handle(executor, i);
         if (RCL_RET_OK != ret) {
           RCL_SET_ERROR_MSG("Failed to remove handle in rclc_executor_remove_timer.");
@@ -716,7 +713,6 @@ rclc_executor_remove_timer(
         executor->info.number_of_timers--;
         RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Removed a timer.");
         return ret;
-
       }
     }
   }
@@ -734,9 +730,8 @@ rclc_executor_remove_client(
   rcl_ret_t ret = RCL_RET_OK;
 
   for (size_t i = 0; (i < executor->max_handles && executor->handles[i].initialized); i++) {
-    if(CLIENT == executor->handles[i].type){
-      if(client == executor->handles[i].client)
-      {
+    if(CLIENT == executor->handles[i].type) {
+      if(client == executor->handles[i].client) {
         _rclc_executor_remove_handle(executor, i);
         if (RCL_RET_OK != ret) {
           RCL_SET_ERROR_MSG("Failed to remove handle in rclc_executor_remove_client.");
@@ -745,7 +740,6 @@ rclc_executor_remove_client(
         executor->info.number_of_clients--;
         RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Removed a client.");
         return ret;
-
       }
     }
   }
@@ -763,9 +757,8 @@ rclc_executor_remove_service(
   rcl_ret_t ret = RCL_RET_OK;
 
   for (size_t i = 0; (i < executor->max_handles && executor->handles[i].initialized); i++) {
-    if(SERVICE == executor->handles[i].type){
-      if(service == executor->handles[i].service)
-      {
+    if(SERVICE == executor->handles[i].type) {
+      if(service == executor->handles[i].service) {
         _rclc_executor_remove_handle(executor, i);
         if (RCL_RET_OK != ret) {
           RCL_SET_ERROR_MSG("Failed to remove handle in rclc_executor_remove_service.");
@@ -774,7 +767,6 @@ rclc_executor_remove_service(
         executor->info.number_of_services--;
         RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Removed a service.");
         return ret;
-
       }
     }
   }
@@ -791,11 +783,10 @@ rclc_executor_remove_guard_condition(
   RCL_CHECK_ARGUMENT_FOR_NULL(executor, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(guard_condition, RCL_RET_INVALID_ARGUMENT);
   rcl_ret_t ret = RCL_RET_OK;
-  
+
   for (size_t i = 0; (i < executor->max_handles && executor->handles[i].initialized); i++) {
-    if(GUARD_CONDITION == executor->handles[i].type){
-      if(guard_condition == executor->handles[i].gc)
-      {
+    if(GUARD_CONDITION == executor->handles[i].type) {
+      if(guard_condition == executor->handles[i].gc) {
         _rclc_executor_remove_handle(executor, i);
         if (RCL_RET_OK != ret) {
           RCL_SET_ERROR_MSG("Failed to remove handle in rclc_executor_remove_guard_condition.");
@@ -804,16 +795,12 @@ rclc_executor_remove_guard_condition(
         executor->info.number_of_guard_conditions--;
         RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Removed a guard condition.");
         return ret;
-
       }
     }
   }
   RCL_SET_ERROR_MSG("Guard Condition not found in rclc_executor_remove_guard_condition");
   return RCL_RET_ERROR;
 }
-
-
-
 
 
 

--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -272,9 +272,10 @@ rclc_executor_add_subscription_with_context(
   executor->handles[executor->index].type = SUBSCRIPTION;
   executor->handles[executor->index].subscription = subscription;
   executor->handles[executor->index].data = msg;
-  executor->handles[executor->index].callback = callback;
+  executor->handles[executor->index].subscription_callback_with_context = callback;
   executor->handles[executor->index].invocation = invocation;
   executor->handles[executor->index].initialized = true;
+  executor->handles[executor->index].callback_context = context;
 
   // increase index of handle array
   executor->index++;
@@ -818,6 +819,7 @@ _rclc_execute(rclc_executor_handle_t * handle)
                 handle->callback_context);
             }
             break;
+        }
         break;
 
       case TIMER:

--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -287,7 +287,7 @@ rclc_executor_add_subscription_with_context(
   if (rcl_wait_set_is_valid(&executor->wait_set)) {
     ret = rcl_wait_set_fini(&executor->wait_set);
     if (RCL_RET_OK != ret) {
-      RCL_SET_ERROR_MSG("Could not reset wait_set in rclc_executor_add_subscription.");
+      RCL_SET_ERROR_MSG("Could not reset wait_set in rclc_executor_add_subscription_with_context.");
       return ret;
     }
   }
@@ -625,6 +625,197 @@ rclc_executor_add_guard_condition(
   RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Added a guard_condition.");
   return ret;
 }
+
+
+
+
+rcl_ret_t
+_rclc_executor_remove_handle(rclc_executor_t * executor, size_t handle_index)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(executor, RCL_RET_INVALID_ARGUMENT);
+  rcl_ret_t ret = RCL_RET_OK;
+
+  if (handle_index >= executor->index) {
+    RCL_SET_ERROR_MSG("Handle out of bounds");
+    return RCL_RET_ERROR;
+  }
+  if (0 == executor->index) {
+    RCL_SET_ERROR_MSG("No handles to remove");
+    return RCL_RET_ERROR;
+  }
+
+  //shorten the list of handles by moving the last handle to the Nth position.
+  executor->index--;
+  executor->handles[handle_index] = executor->handles[executor->index];
+  ret = rclc_executor_handle_init(&executor->handles[executor->index], executor->max_handles);
+
+  //force a refresh of the wait set
+  if (rcl_wait_set_is_valid(&executor->wait_set)) {
+    ret = rcl_wait_set_fini(&executor->wait_set);
+    if (RCL_RET_OK != ret) {
+      RCL_SET_ERROR_MSG("Could not reset wait_set in _rclc_executor_remove_handle.");
+      return ret;
+    }
+  }
+
+  RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Removed a handle.");
+  return ret;
+}
+
+
+
+rcl_ret_t
+rclc_executor_remove_subscription(
+  rclc_executor_t * executor,
+  const rcl_subscription_t * subscription)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(executor, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(subscription, RCL_RET_INVALID_ARGUMENT);
+  rcl_ret_t ret = RCL_RET_OK;
+
+  for (size_t i = 0; (i < executor->max_handles && executor->handles[i].initialized); i++) {
+    if(SUBSCRIPTION == executor->handles[i].type){
+      if(subscription == executor->handles[i].subscription)
+      {
+        ret = _rclc_executor_remove_handle(executor, i);
+        if (RCL_RET_OK != ret) {
+          RCL_SET_ERROR_MSG("Failed to remove handle in rclc_executor_remove_subscription.");
+          return ret;
+        }
+        executor->info.number_of_subscriptions--;
+        RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Removed a subscription.");
+        return ret;
+
+      }
+    }
+  }
+  RCL_SET_ERROR_MSG("Subscription not found in rclc_executor_remove_subscription");
+  return RCL_RET_ERROR;
+}
+
+rcl_ret_t
+rclc_executor_remove_timer(
+  rclc_executor_t * executor,
+  const rcl_timer_t * timer)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(executor, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(subscription, RCL_RET_INVALID_ARGUMENT);
+  rcl_ret_t ret = RCL_RET_OK;
+
+  for (size_t i = 0; (i < executor->max_handles && executor->handles[i].initialized); i++) {
+    if(TIMER == executor->handles[i].type){
+      if(timer == executor->handles[i].timer)
+      {
+        _rclc_executor_remove_handle(executor, i);
+        if (RCL_RET_OK != ret) {
+          RCL_SET_ERROR_MSG("Failed to remove handle in rclc_executor_remove_timer.");
+          return ret;
+        }
+        executor->info.number_of_timers--;
+        RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Removed a timer.");
+        return ret;
+
+      }
+    }
+  }
+  RCL_SET_ERROR_MSG("Timer not found in rclc_executor_remove_timer");
+  return RCL_RET_ERROR;
+}
+
+rcl_ret_t
+rclc_executor_remove_client(
+  rclc_executor_t * executor,
+  const rcl_client_t * client)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(executor, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(client, RCL_RET_INVALID_ARGUMENT);
+  rcl_ret_t ret = RCL_RET_OK;
+
+  for (size_t i = 0; (i < executor->max_handles && executor->handles[i].initialized); i++) {
+    if(CLIENT == executor->handles[i].type){
+      if(client == executor->handles[i].client)
+      {
+        _rclc_executor_remove_handle(executor, i);
+        if (RCL_RET_OK != ret) {
+          RCL_SET_ERROR_MSG("Failed to remove handle in rclc_executor_remove_client.");
+          return ret;
+        }
+        executor->info.number_of_clients--;
+        RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Removed a client.");
+        return ret;
+
+      }
+    }
+  }
+  RCL_SET_ERROR_MSG("Client not found in rclc_executor_remove_client");
+  return RCL_RET_ERROR;
+}
+
+rcl_ret_t
+rclc_executor_remove_service(
+  rclc_executor_t * executor,
+  const rcl_service_t * service)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(executor, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(service, RCL_RET_INVALID_ARGUMENT);
+  rcl_ret_t ret = RCL_RET_OK;
+
+  for (size_t i = 0; (i < executor->max_handles && executor->handles[i].initialized); i++) {
+    if(SERVICE == executor->handles[i].type){
+      if(service == executor->handles[i].service)
+      {
+        _rclc_executor_remove_handle(executor, i);
+        if (RCL_RET_OK != ret) {
+          RCL_SET_ERROR_MSG("Failed to remove handle in rclc_executor_remove_service.");
+          return ret;
+        }
+        executor->info.number_of_services--;
+        RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Removed a service.");
+        return ret;
+
+      }
+    }
+  }
+  RCL_SET_ERROR_MSG("Service not found in rclc_executor_remove_service");
+  return RCL_RET_ERROR;
+}
+
+
+rcl_ret_t
+rclc_executor_remove_guard_condition(
+  rclc_executor_t * executor,
+  const rcl_guard_condition_t * guard_condition)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(executor, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(guard_condition, RCL_RET_INVALID_ARGUMENT);
+  rcl_ret_t ret = RCL_RET_OK;
+  
+  for (size_t i = 0; (i < executor->max_handles && executor->handles[i].initialized); i++) {
+    if(GUARD_CONDITION == executor->handles[i].type){
+      if(guard_condition == executor->handles[i].guard_condition)
+      {
+        _rclc_executor_remove_handle(executor, i);
+        if (RCL_RET_OK != ret) {
+          RCL_SET_ERROR_MSG("Failed to remove handle in rclc_executor_remove_guard_condition.");
+          return ret;
+        }
+        executor->info.number_of_guard_conditions--;
+        RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Removed a guard condition.");
+        return ret;
+
+      }
+    }
+  }
+  RCL_SET_ERROR_MSG("Guard Condition not found in rclc_executor_remove_guard_condition");
+  return RCL_RET_ERROR;
+}
+
+
+
+
+
+
+
 /***
  * operates on handle executor->handles[i]
  * - evaluates the status bit in the wait_set for this handle

--- a/rclc/src/rclc/executor_handle.c
+++ b/rclc/src/rclc/executor_handle.c
@@ -48,7 +48,7 @@ rclc_executor_handle_init(
 
   handle->data = NULL;
   handle->data_response_msg = NULL;
-  handle->service_context = NULL;
+  handle->callback_context = NULL;
 
   handle->callback = NULL;
   // because of union structure:


### PR DESCRIPTION
This follows https://github.com/ros2/rclc/issues/50
This adds `rclc_executor_add_subscription_with_context` allowing a subscription to avoid calls to global namespace.

