### PR TITLE
Backport: codecov support for Foxy branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     - uses : ros-tooling/action-ros-ci@0.1.0
       with:
         package-name: "rclc rclc_examples rclc_lifecycle"
-        vcs-repo-file-url: dependencies.repos
+        vcs-repo-file-url: ""
         target-ros2-distro: ${{ matrix.ros_distribution }}
         colcon-mixin-name: coverage-gcc
         colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,13 @@ jobs:
       run: |
         apt-get install ros-${{ matrix.ros_distribution }}-osrf-testing-tools-cpp
         apt-get install ros-${{ matrix.ros_distribution }}-test-msgs
-
     - uses : ros-tooling/action-ros-ci@0.1.0
       with:
         package-name: "rclc rclc_examples rclc_lifecycle"
-        vcs-repo-file-url: ""
+        vcs-repo-file-url: dependencies.repos
         target-ros2-distro: ${{ matrix.ros_distribution }}
+        colcon-mixin-name: coverage-gcc
+        colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
+    - uses: codecov/codecov-action@v1
+      with:
+        file: ros_ws/lcov/total_coverage.info

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+ignore:
+  - "rclc_examples"
+  - "rclc/test"
+  - "rclc_lifecycle/test"


### PR DESCRIPTION
@ralph-lange , @norro :
backport of code coverage for Foxy branch.
see issue https://github.com/ros2/rclc/issues/81
(changes partly made in PR: https://github.com/ros2/rclc/pull/74)

applied changes:
- commit https://github.com/ros2/rclc/commit/905aaf94ac7dac2955cb179e342bf344ef235767
- commit https://github.com/ros2/rclc/pull/74/commits/b9685194b725383dcec3618b26ccac4b033d13e3
