### PR TITLE
Backport: windows port for Foxy branch

### DIFF
--- a/rclc/CMakeLists.txt
+++ b/rclc/CMakeLists.txt
@@ -70,22 +70,47 @@ target_include_directories(${PROJECT_NAME}
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
 )
 
+target_link_libraries(${PROJECT_NAME} ${CMAKE_THREAD_LIBS_INIT})
+# specific order: dependents before dependencies
 ament_target_dependencies(${PROJECT_NAME}
   rcl
   rcutils
   rosidl_generator_c
 )
 
-
 #################################################
 # install
 #################################################
-install(DIRECTORY include/ DESTINATION include)
-install(TARGETS ${PROJECT_NAME} DESTINATION lib)
+#install(DIRECTORY include/ DESTINATION include)
+#install(TARGETS ${PROJECT_NAME} DESTINATION lib)
+
+# Causes the visibility macros to use dllexport rather than dllimport,
+# which is appropriate when building the dll but not consuming it.
+target_compile_definitions(${PROJECT_NAME}
+  PRIVATE "RCLC_BUILDING_LIBRARY")
+
+install(
+  TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
 
 # specific order: dependents before dependencies
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})
+
+if("${rcl_VERSION}" VERSION_LESS "1.1.10")
+# ament_export_targets command is not available for Dashing
+else()
+ament_export_targets(${PROJECT_NAME})
+endif()
+
 
 #################################################
 # gtest
@@ -123,6 +148,8 @@ if(BUILD_TESTING)
     test_msgs
     example_interfaces
   )
+
+
 endif()
 
 #################################################

--- a/rclc/include/rclc/client.h
+++ b/rclc/include/rclc/client.h
@@ -24,6 +24,7 @@ extern "C"
 #include <rcl/client.h>
 #include <rcl/allocator.h>
 #include <rclc/types.h>
+#include <rclc/visibility_control.h>
 
 /**
  *  Creates an rcl client.
@@ -43,6 +44,7 @@ extern "C"
  * \return `RCL_RET_OK` if successful
  * \return `RCL_ERROR` (or other error code) if an error has occurred
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_client_init_default(
   rcl_client_t * client,
@@ -68,6 +70,7 @@ rclc_client_init_default(
  * \return `RCL_RET_OK` if successful
  * \return `RCL_ERROR` (or other error code) if an error has occurred
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_client_init_best_effort(
   rcl_client_t * client,

--- a/rclc/include/rclc/executor.h
+++ b/rclc/include/rclc/executor.h
@@ -29,6 +29,15 @@ extern "C"
 
 #include "rclc/executor_handle.h"
 #include "rclc/types.h"
+#include "rclc/visibility_control.h"
+
+#ifdef WIN32
+#include <Windows.h>
+#define rclc_sleep_ms(x) Sleep(x)
+#else
+#include <unistd.h>
+#define rclc_sleep_ms(x) usleep(x * 1000)
+#endif
 
 /*! \file executor.h
     \brief The RCLC-Executor provides an Executor based on RCL in which all callbacks are
@@ -84,6 +93,7 @@ typedef struct
  *  Return a rclc_executor_t struct with pointer members initialized to `NULL`
  *  and member variables to 0.
  */
+RCLC_PUBLIC
 rclc_executor_t
 rclc_executor_get_zero_initialized_executor(void);
 
@@ -110,6 +120,7 @@ rclc_executor_get_zero_initialized_executor(void);
  * \return `RCL_RET_INVALID_ARGUMENT` if any null pointer as argument
  * \return `RCL_RET_ERROR` in case of failure
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_executor_init(
   rclc_executor_t * executor,
@@ -134,6 +145,7 @@ rclc_executor_init(
  * \return `RCL_RET_INVALID_ARGUMENT` if \p executor is a null pointer
  * \return `RCL_RET_ERROR` in an error occured
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_executor_set_timeout(
   rclc_executor_t * executor,
@@ -155,6 +167,7 @@ rclc_executor_set_timeout(
  * \return `RCL_RET_OK` if semantics was set successfully
  * \return `RCL_RET_INVALID_ARGUMENT` if \p executor is a null pointer
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_executor_set_semantics(
   rclc_executor_t * executor,
@@ -179,6 +192,7 @@ rclc_executor_set_semantics(
  * \return `RCL_RET_INVALID_ARGUMENT` if \p executor.handles is a null pointer
  * \return `RCL_RET_ERROR` in an error occured (aka executor was not initialized)
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_executor_fini(rclc_executor_t * executor);
 
@@ -205,6 +219,7 @@ rclc_executor_fini(rclc_executor_t * executor);
  * \return `RCL_RET_INVALID_ARGUMENT` if any parameter is a null pointer
  * \return `RCL_RET_ERROR` if any other error occured
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_executor_add_subscription(
   rclc_executor_t * executor,
@@ -233,6 +248,7 @@ rclc_executor_add_subscription(
  * \return `RCL_RET_INVALID_ARGUMENT` if any parameter is a null pointer
  * \return `RCL_RET_ERROR` if any other error occured
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_executor_add_timer(
   rclc_executor_t * executor,
@@ -261,6 +277,7 @@ rclc_executor_add_timer(
  * \return `RCL_RET_INVALID_ARGUMENT` if any parameter is a null pointer
  * \return `RCL_RET_ERROR` if any other error occured
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_executor_add_client(
   rclc_executor_t * executor,
@@ -290,6 +307,7 @@ rclc_executor_add_client(
  * \return `RCL_RET_INVALID_ARGUMENT` if any parameter is a null pointer
  * \return `RCL_RET_ERROR` if any other error occured
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_executor_add_client_with_request_id(
   rclc_executor_t * executor,
@@ -320,6 +338,7 @@ rclc_executor_add_client_with_request_id(
  * \return `RCL_RET_INVALID_ARGUMENT` if any parameter is a null pointer
  * \return `RCL_RET_ERROR` if any other error occured
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_executor_add_service(
   rclc_executor_t * executor,
@@ -351,6 +370,7 @@ rclc_executor_add_service(
  * \return `RCL_RET_INVALID_ARGUMENT` if any parameter is a null pointer
  * \return `RCL_RET_ERROR` if any other error occured
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_executor_add_service_with_request_id(
   rclc_executor_t * executor,
@@ -383,6 +403,7 @@ rclc_executor_add_service_with_request_id(
  * \return `RCL_RET_INVALID_ARGUMENT` if any parameter is a null pointer
  * \return `RCL_RET_ERROR` if any other error occured
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_executor_add_service_with_context(
   rclc_executor_t * executor,
@@ -413,6 +434,7 @@ rclc_executor_add_service_with_context(
  * \return `RCL_RET_INVALID_ARGUMENT` if any parameter is a null pointer
  * \return `RCL_RET_ERROR` if any other error occured
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_executor_add_guard_condition(
   rclc_executor_t * executor,
@@ -449,6 +471,7 @@ rclc_executor_add_guard_condition(
  * \return `RCL_RET_TIMEOUT` if rcl_wait() returned timeout (aka no data is avaiable during until the timeout)
  * \return `RCL_RET_ERROR` if any other error occured
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_executor_spin_some(
   rclc_executor_t * executor,
@@ -475,6 +498,7 @@ rclc_executor_spin_some(
  * \return `RCL_RET_INVALID_ARGUMENT` if executor is a null pointer
  * \return `RCL_RET_ERROR` if any other error occured
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_executor_spin(rclc_executor_t * executor);
 
@@ -500,6 +524,7 @@ rclc_executor_spin(rclc_executor_t * executor);
  * \return `RCL_RET_INVALID_ARGUMENT` if executor is a null pointer
  * \return `RCL_RET_ERROR` if any other error occured
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_executor_spin_period(
   rclc_executor_t * executor,
@@ -528,6 +553,7 @@ rclc_executor_spin_period(
  * \return `RCL_RET_INVALID_ARGUMENT` if executor is a null pointer
  * \return `RCL_RET_ERROR` if any other error occured
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_executor_spin_one_period(
   rclc_executor_t * executor,
@@ -552,6 +578,7 @@ rclc_executor_spin_one_period(
  * \return `RCL_RET_INVALID_ARGUMENT` if executor is a null pointer
  * \return `RCL_RET_ERROR` if any other error occured
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_executor_set_trigger(
   rclc_executor_t * executor,
@@ -576,6 +603,7 @@ rclc_executor_set_trigger(
  * \return true - if all handles are ready (subscriptions have new data, timers are ready)
  * \return false - otherwise
  */
+RCLC_PUBLIC
 bool
 rclc_executor_trigger_all(
   rclc_executor_handle_t * handles,
@@ -600,6 +628,7 @@ rclc_executor_trigger_all(
  * \return true - if at least one handles is ready (subscriptions have new data, timers are ready)
  * \return false - otherwise
  */
+RCLC_PUBLIC
 bool
 rclc_executor_trigger_any(
   rclc_executor_handle_t * handles,
@@ -623,6 +652,7 @@ rclc_executor_trigger_any(
  * \param [in] obj trigger_object set by rclc_executor_set_trigger (not used)
  * \return true always
  */
+RCLC_PUBLIC
 bool
 rclc_executor_trigger_always(
   rclc_executor_handle_t * handles,
@@ -648,6 +678,7 @@ rclc_executor_trigger_always(
  * \return true if rcl-handle obj is ready
  * \return false otherwise
  */
+RCLC_PUBLIC
 bool
 rclc_executor_trigger_one(
   rclc_executor_handle_t * handles,

--- a/rclc/include/rclc/executor_handle.h
+++ b/rclc/include/rclc/executor_handle.h
@@ -22,6 +22,7 @@ extern "C"
 #endif
 
 #include <rcl/rcl.h>
+#include <rclc/visibility_control.h>
 
 /// TODO (jst3si) Where is this defined? - in my build environment this variable is not set.
 // #define ROS_PACKAGE_NAME "rclc"
@@ -183,6 +184,7 @@ typedef struct
  * \param[inout] handle_counters preallocated rclc_executor_handle_counters_t
  * \return `RCL_RET_INVALID_ARGUMENT` if `handle_counters` is a null pointer
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_executor_handle_counters_zero_init(rclc_executor_handle_counters_t * handle_counters);
 
@@ -206,6 +208,7 @@ rclc_executor_handle_counters_zero_init(rclc_executor_handle_counters_t * handle
  * \return `RCL_RET_OK` if the \p handle was initialized successfully
  * \return `RCL_RET_INVALID_ARGUMENT` if \p h is a null pointer
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_executor_handle_init(
   rclc_executor_handle_t * handle,
@@ -229,6 +232,7 @@ rclc_executor_handle_init(
  * \return `RCL_RET_OK` if \p h was cleared successfully
  * \return `RCL_RET_INVALID_ARGUMENT` if \p h is a null pointer
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_executor_handle_clear(
   rclc_executor_handle_t * handle,
@@ -249,6 +253,7 @@ rclc_executor_handle_clear(
  * \return `RCL_RET_OK` if the handle was printed successfully
  * \return `RCL_RET_INVALID_ARGUMENT` if \p h is a null pointer
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_executor_handle_print(rclc_executor_handle_t * handle);
 
@@ -270,6 +275,7 @@ rclc_executor_handle_print(rclc_executor_handle_t * handle);
  * \return pointer to the rcl-handle (rcl_subscription_t or rcl_timer_t)
  * \return NULL, if handle is a NULL pointer.
  */
+RCLC_PUBLIC
 void *
 rclc_executor_handle_get_ptr(rclc_executor_handle_t * handle);
 

--- a/rclc/include/rclc/init.h
+++ b/rclc/include/rclc/init.h
@@ -24,6 +24,7 @@ extern "C"
 
 #include <rcl/allocator.h>
 #include "rclc/types.h"
+#include "rclc/visibility_control.h"
 
 /**
  *  Initializes rcl and creates some support data structures.
@@ -44,6 +45,7 @@ extern "C"
  * \return `RCL_RET_INVALID_ARGUMENT` if any null pointer as argument
  * \return `RCL_RET_ERROR` in case of failure
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_support_init(
   rclc_support_t * support,
@@ -71,6 +73,7 @@ rclc_support_init(
  * \return `RCL_RET_INVALID_ARGUMENT` if any null pointer as argument
  * \return `RCL_RET_ERROR` in case of failure
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_support_init_with_options(
   rclc_support_t * support,
@@ -96,6 +99,7 @@ rclc_support_init_with_options(
  * \return `RCL_RET_INVALID_ARGUMENT` if any null pointer as argument
  * \return `RCL_RET_ERROR` in case of failure
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_support_fini(
   rclc_support_t * support);

--- a/rclc/include/rclc/node.h
+++ b/rclc/include/rclc/node.h
@@ -25,6 +25,7 @@ extern "C"
 #include <rclc/types.h>
 
 #include <rclc/init.h>
+#include "rclc/visibility_control.h"
 /**
  *  Creates a default RCL node.
  *
@@ -42,6 +43,7 @@ extern "C"
  * \return rcl_node_t if successful
  * \return NULL if an error occurred
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_node_init_default(
   rcl_node_t * node,
@@ -67,6 +69,7 @@ rclc_node_init_default(
  * \return rcl_node_t if successful
  * \return NULL if an error occurred
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_node_init_with_options(
   rcl_node_t * node,

--- a/rclc/include/rclc/publisher.h
+++ b/rclc/include/rclc/publisher.h
@@ -26,6 +26,7 @@ extern "C"
 // #include<rcl/node.h>
 #include <rcl/allocator.h>
 #include <rclc/types.h>
+#include "rclc/visibility_control.h"
 
 /**
  *  Creates an rcl publisher.
@@ -45,6 +46,7 @@ extern "C"
  * \return `RCL_RET_OK` if successful
  * \return `RCL_ERROR` (or other error code) if an error has occurred
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_publisher_init_default(
   rcl_publisher_t * publisher,
@@ -70,6 +72,7 @@ rclc_publisher_init_default(
  * \return `RCL_RET_OK` if successful
  * \return `RCL_ERROR` (or other error code) if an error has occurred
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_publisher_init_best_effort(
   rcl_publisher_t * publisher,

--- a/rclc/include/rclc/rclc.h
+++ b/rclc/include/rclc/rclc.h
@@ -33,7 +33,7 @@ extern "C"
 #include "rclc/client.h"
 #include "rclc/service.h"
 #include "rclc/types.h"
-
+#include "rclc/visibility_control.h"
 #if __cplusplus
 }
 #endif

--- a/rclc/include/rclc/service.h
+++ b/rclc/include/rclc/service.h
@@ -24,6 +24,7 @@ extern "C"
 #include <rcl/service.h>
 #include <rcl/allocator.h>
 #include <rclc/types.h>
+#include "rclc/visibility_control.h"
 
 /**
  *  Creates an rcl service.
@@ -43,6 +44,7 @@ extern "C"
  * \return `RCL_RET_OK` if successful
  * \return `RCL_ERROR` (or other error code) if an error has occurred
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_service_init_default(
   rcl_service_t * service,
@@ -68,6 +70,7 @@ rclc_service_init_default(
  * \return `RCL_RET_OK` if successful
  * \return `RCL_ERROR` (or other error code) if an error has occurred
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_service_init_best_effort(
   rcl_service_t * service,

--- a/rclc/include/rclc/subscription.h
+++ b/rclc/include/rclc/subscription.h
@@ -24,6 +24,7 @@ extern "C"
 #include <rcl/subscription.h>
 #include <rclc/types.h>
 #include <rclc/init.h>
+#include "rclc/visibility_control.h"
 
 /**
  *  Creates an rcl subscription.
@@ -43,6 +44,7 @@ extern "C"
  * \return `RCL_RET_OK` if successful
  * \return `RCL_ERROR` (or other error code) if an error occurred
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_subscription_init_default(
   rcl_subscription_t * subscription,
@@ -68,6 +70,7 @@ rclc_subscription_init_default(
  * \return `RCL_RET_OK` if successful
  * \return `RCL_ERROR` (or other error code) if an error occurred
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_subscription_init_best_effort(
   rcl_subscription_t * subscription,

--- a/rclc/include/rclc/timer.h
+++ b/rclc/include/rclc/timer.h
@@ -23,6 +23,7 @@ extern "C"
 
 #include <rcl/timer.h>
 #include <rclc/types.h>
+#include "rclc/visibility_control.h"
 
 /**
  *  Creates an rcl timer.
@@ -42,6 +43,7 @@ extern "C"
  * \return `RCL_RET_OK` if successful
  * \return `RCL_ERROR` (or other error code) if an error occurred
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_timer_init_default(
   rcl_timer_t * timer,

--- a/rclc/include/rclc/visibility_control.h
+++ b/rclc/include/rclc/visibility_control.h
@@ -1,0 +1,58 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLC__VISIBILITY_CONTROL_H_
+#define RCLC__VISIBILITY_CONTROL_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define RCLC_EXPORT __attribute__ ((dllexport))
+    #define RCLC_IMPORT __attribute__ ((dllimport))
+  #else
+    #define RCLC_EXPORT __declspec(dllexport)
+    #define RCLC_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef RCLC_BUILDING_LIBRARY
+    #define RCLC_PUBLIC RCLC_EXPORT
+  #else
+    #define RCLC_PUBLIC RCLC_IMPORT
+  #endif
+  #define RCLC_PUBLIC_TYPE RCLC_PUBLIC
+  #define RCLC_LOCAL
+#else
+  #define RCLC_EXPORT __attribute__ ((visibility("default")))
+  #define RCLC_IMPORT
+  #if __GNUC__ >= 4
+    #define RCLC_PUBLIC __attribute__ ((visibility("default")))
+    #define RCLC_LOCAL  __attribute__ ((visibility("hidden")))
+  #else
+    #define RCLC_PUBLIC
+    #define RCLC_LOCAL
+  #endif
+  #define RCLC_PUBLIC_TYPE
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RCLC__VISIBILITY_CONTROL_H_

--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -15,9 +15,6 @@
 // limitations under the License.
 
 #include "rclc/executor.h"
-
-#include <unistd.h>
-
 #include <rcutils/time.h>
 
 // Include backport of function 'rcl_wait_set_is_valid' introduced in Foxy
@@ -1108,7 +1105,7 @@ rclc_executor_spin_one_period(rclc_executor_t * executor, const uint64_t period)
   ret = rcutils_system_time_now(&end_time_point);
   sleep_time = (executor->invocation_time + period) - end_time_point;
   if (sleep_time > 0) {
-    usleep(sleep_time / 1000);
+    rclc_sleep_ms(sleep_time / 1000000);
   }
   executor->invocation_time += period;
   return ret;

--- a/rclc_examples/src/example_client_node.c
+++ b/rclc_examples/src/example_client_node.c
@@ -19,7 +19,6 @@
 #include "example_interfaces/srv/add_two_ints.h"
 
 #include <stdio.h>
-#include <unistd.h>
 
 #define RCCHECK(fn) {rcl_ret_t temp_rc = fn; if ((temp_rc != RCL_RET_OK)) {printf( \
         "Failed status on line %d: %d. Aborting.\n", __LINE__, (int)temp_rc); return 1;}}
@@ -71,7 +70,7 @@ int main(int argc, const char * const * argv)
   req.a = 24;
   req.b = 42;
 
-  sleep(2);   // Sleep a while to ensure DDS matching before sending request
+  rclc_sleep_ms(2000);   // Sleep a while to ensure DDS matching before sending request
 
   RCCHECK(rcl_send_request(&client, &req, &seq))
   printf("Send service request %ld + %ld.\n", req.a, req.b);

--- a/rclc_examples/src/example_executor_trigger.c
+++ b/rclc_examples/src/example_executor_trigger.c
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include <stdio.h>
-#include <unistd.h>
 
 #include <std_msgs/msg/string.h>
 #include <std_msgs/msg/int32.h>
@@ -373,7 +372,7 @@ int main(int argc, const char * argv[])
   for (unsigned int i = 0; i < 100; i++) {
     // timeout specified in ns                 (here: 1s)
     rclc_executor_spin_some(&executor_pub, 1000 * (1000 * 1000));
-    usleep(1000); // 1ms
+    rclc_sleep_ms(1); // 1ms
     rclc_executor_spin_some(&executor_sub, 1000 * (1000 * 1000));
   }
 

--- a/rclc_examples/src/example_lifecycle_node.c
+++ b/rclc_examples/src/example_lifecycle_node.c
@@ -15,7 +15,6 @@
 // limitations under the License.
 
 #include <stdio.h>
-#include <unistd.h>
 
 #include <rcl/error_handling.h>
 #include <rcutils/logging_macros.h>

--- a/rclc_examples/src/example_service_node.c
+++ b/rclc_examples/src/example_service_node.c
@@ -20,7 +20,6 @@
 #include "example_interfaces/srv/add_two_ints.h"
 
 #include <stdio.h>
-#include <unistd.h>
 
 #define RCCHECK(fn) {rcl_ret_t temp_rc = fn; if ((temp_rc != RCL_RET_OK)) {printf( \
         "Failed status on line %d: %d. Aborting.\n", __LINE__, (int)temp_rc); return 1;}}

--- a/rclc_lifecycle/CMakeLists.txt
+++ b/rclc_lifecycle/CMakeLists.txt
@@ -36,6 +36,7 @@ target_include_directories(${PROJECT_NAME}
     PRIVATE
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
 )
+target_link_libraries(${PROJECT_NAME} ${CMAKE_THREAD_LIBS_INIT})
 ament_target_dependencies(${PROJECT_NAME}
   rclc
   rcutils
@@ -43,12 +44,36 @@ ament_target_dependencies(${PROJECT_NAME}
   lifecycle_msgs
 )
 
+# Causes the visibility macros to use dllexport rather than dllimport,
+# which is appropriate when building the dll but not consuming it.
+target_compile_definitions(${PROJECT_NAME}
+  PRIVATE "RCLC_LIFECYCLE_BUILDING_LIBRARY")
+
+
 # install
-install(DIRECTORY include/ DESTINATION include)
-install(TARGETS ${PROJECT_NAME} DESTINATION lib)
+#install(DIRECTORY include/ DESTINATION include)
+#install(TARGETS ${PROJECT_NAME} DESTINATION lib)
+
+install(
+  TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
 
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})
+
+if("${rcl_VERSION}" VERSION_LESS "1.1.10")
+# ament_export_targets command is not available for Dashing
+else()
+ament_export_targets(${PROJECT_NAME})
+endif()
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)

--- a/rclc_lifecycle/include/rclc_lifecycle/rclc_lifecycle.h
+++ b/rclc_lifecycle/include/rclc_lifecycle/rclc_lifecycle.h
@@ -24,6 +24,7 @@
 #include <rcl_lifecycle/rcl_lifecycle.h>
 
 #include "rclc/node.h"
+#include "rclc_lifecycle/visibility_control.h"
 
 typedef struct rclc_lifecycle_callback_map_t
 {
@@ -39,6 +40,7 @@ typedef struct rclc_lifecycle_node_t
   rclc_lifecycle_callback_map_t callbacks;
 } rclc_lifecycle_node_t;
 
+RCLC_LIFECYCLE_PUBLIC
 rcl_ret_t
 rclc_make_node_a_lifecycle_node(
   rclc_lifecycle_node_t * lifecycle_node,
@@ -46,43 +48,51 @@ rclc_make_node_a_lifecycle_node(
   rcl_lifecycle_state_machine_t * state_machine,
   rcl_allocator_t * allocator);
 
+RCLC_LIFECYCLE_PUBLIC
 rcl_ret_t
 rclc_lifecycle_change_state(
   rclc_lifecycle_node_t * lifecycle_node,
   unsigned int transition_id,
   bool publish_update);
 
+RCLC_LIFECYCLE_PUBLIC
 rcl_ret_t
 rclc_lifecycle_register_callback(
   rclc_lifecycle_node_t * lifecycle_node,
   unsigned int goal_state,
   int (* cb)(void));
 
+RCLC_LIFECYCLE_PUBLIC
 rcl_ret_t
 rclc_lifecycle_register_on_configure(
   rclc_lifecycle_node_t * node,
   int (* cb)(void));
 
+RCLC_LIFECYCLE_PUBLIC
 rcl_ret_t
 rclc_lifecycle_register_on_activate(
   rclc_lifecycle_node_t * node,
   int (* cb)(void));
 
+RCLC_LIFECYCLE_PUBLIC
 rcl_ret_t
 rclc_lifecycle_register_on_deactivate(
   rclc_lifecycle_node_t * node,
   int (* cb)(void));
 
+RCLC_LIFECYCLE_PUBLIC
 rcl_ret_t
 rclc_lifecycle_register_on_cleanup(
   rclc_lifecycle_node_t * node,
   int (* cb)(void));
 
+RCLC_LIFECYCLE_PUBLIC
 rcl_ret_t
 rclc_lifecycle_execute_callback(
   rclc_lifecycle_node_t * lifecycle_node,
   unsigned int transition_id);
 
+RCLC_LIFECYCLE_PUBLIC
 rcl_ret_t
 rcl_lifecycle_node_fini(
   rclc_lifecycle_node_t * node,

--- a/rclc_lifecycle/include/rclc_lifecycle/visibility_control.h
+++ b/rclc_lifecycle/include/rclc_lifecycle/visibility_control.h
@@ -1,0 +1,58 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLC_LIFECYCLE__VISIBILITY_CONTROL_H_
+#define RCLC_LIFECYCLE__VISIBILITY_CONTROL_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define RCLC_LIFECYCLE_EXPORT __attribute__ ((dllexport))
+    #define RCLC_LIFECYCLE_IMPORT __attribute__ ((dllimport))
+  #else
+    #define RCLC_LIFECYCLE_EXPORT __declspec(dllexport)
+    #define RCLC_LIFECYCLE_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef RCLC_LIFECYCLE_BUILDING_LIBRARY
+    #define RCLC_LIFECYCLE_PUBLIC RCLC_LIFECYCLE_EXPORT
+  #else
+    #define RCLC_LIFECYCLE_PUBLIC RCLC_LIFECYCLE_IMPORT
+  #endif
+  #define RCLC_LIFECYCLE_PUBLIC_TYPE RCLC_LIFECYCLE_PUBLIC
+  #define RCLC_LIFECYCLE_LOCAL
+#else
+  #define RCLC_LIFECYCLE_EXPORT __attribute__ ((visibility("default")))
+  #define RCLC_LIFECYCLE_IMPORT
+  #if __GNUC__ >= 4
+    #define RCLC_LIFECYCLE_PUBLIC __attribute__ ((visibility("default")))
+    #define RCLC_LIFECYCLE_LOCAL  __attribute__ ((visibility("hidden")))
+  #else
+    #define RCLC_LIFECYCLE_PUBLIC
+    #define RCLC_LIFECYCLE_LOCAL
+  #endif
+  #define RCLC_LIFECYCLE_PUBLIC_TYPE
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RCLC_LIFECYCLE__VISIBILITY_CONTROL_H_


### PR DESCRIPTION
Merged pull request #62 from ros2/feature/windows_port 

For some reason, the existing PR https://github.com/ros2/rclc/pull/69 to backport the windows support for the Foxy branch (Dashing, Foxy release) was never executed on build farm for Dashing. Therefore, I started this second attempt. 

As @norro tested this PR on Windows with Foxy installation in above PR, I guess, this one will run though as well. 
Just for sake of documentation, could you once again run this PR on Windows with ROS 2 Foxy?
