### PR TITLE
replaced github.com/micro-ROS by github.com/ros2

### DIFF
--- a/.github/ISSUE_TEMPLATE/general-issue.md
+++ b/.github/ISSUE_TEMPLATE/general-issue.md
@@ -12,7 +12,7 @@ assignees: ''
 - Hardware description: <!-- hardware where you are using micro-ROS -->
 - RTOS: <!-- RTOS where you are using micro-ROS -->
 - Installation type: <!-- micro_ros_setup, modules, etc  -->
-- Version or commit hash: <!-- version of micro-ROS used: foxy, rolling  -->
+- Version or commit hash: <!-- version of micro-ROS used: foxy, galactic, rolling  -->
 
 #### Steps to reproduce the issue
 <!-- Detailed instructions on how to reliably reproduce this issue http://sscce.org/-->

--- a/rclc_examples/src/example_client_node.c
+++ b/rclc_examples/src/example_client_node.c
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 - for information on the respective copyright owner
-// see the NOTICE file and/or the repository https://github.com/micro-ROS/rclc.
+// see the NOTICE file and/or the repository https://github.com/ros2/rclc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rclc_examples/src/example_executor.c
+++ b/rclc_examples/src/example_executor.c
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 - for information on the respective copyright owner
-// see the NOTICE file and/or the repository https://github.com/micro-ROS/rclc.
+// see the NOTICE file and/or the repository https://github.com/ros2/rclc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rclc_examples/src/example_executor_convenience.c
+++ b/rclc_examples/src/example_executor_convenience.c
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 - for information on the respective copyright owner
-// see the NOTICE file and/or the repository https://github.com/micro-ROS/rclc.
+// see the NOTICE file and/or the repository https://github.com/ros2/rclc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rclc_examples/src/example_executor_trigger.c
+++ b/rclc_examples/src/example_executor_trigger.c
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 - for information on the respective copyright owner
-// see the NOTICE file and/or the repository https://github.com/micro-ROS/rclc.
+// see the NOTICE file and/or the repository https://github.com/ros2/rclc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rclc_examples/src/example_service_node.c
+++ b/rclc_examples/src/example_service_node.c
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 - for information on the respective copyright owner
-// see the NOTICE file and/or the repository https://github.com/micro-ROS/rclc.
+// see the NOTICE file and/or the repository https://github.com/ros2/rclc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
@ralph-lange updated documentation (removed links to github.com/micro-ROS). Could you review this PR and approve?