### PR TITLE
Executor prepare API

### DIFF
--- a/rclc/README.md
+++ b/rclc/README.md
@@ -322,6 +322,9 @@ The second option is useful for example when the callback is expected to be call
 
 For a timer, only the rcl timer object `timer` is needed.
 
+**rclc_executor_prepare(rclc_executor_t * executor)**
+
+The function `rclc_executor_prepare` prepares the internal RCL wait set allocating the required dynamic memory. Its use is optional becouse it also will be checked in the spin functions. If used and no entities are added to the executor during running phase, no dynamic allocations are guaranteed during the running phase.
 #### Running phase
 
 **rclc_executor_spin_some(rclc_executor_t * executor, const uint64_t timeout_ns)**
@@ -394,7 +397,7 @@ void my_timer_cb(rcl_timer_t * timer, int64_t last_call_time)
 }
 
 // necessary ROS 2 objects
-rcl_context_t context;   
+rcl_context_t context;
 rcl_node_t node;
 rcl_subscription_t sub1, sub2, sub3;
 rcl_timer_t timer;

--- a/rclc/include/rclc/executor.h
+++ b/rclc/include/rclc/executor.h
@@ -568,6 +568,30 @@ rclc_executor_remove_guard_condition(
   rclc_executor_t * executor,
   const rcl_guard_condition_t * guard_condition);
 
+/**
+ *  The executor prepare function prepare the waitset of the executor if
+ *  it is invalid. Does nothing if a valid waitset is already prepared.
+ *
+ * Memory is dynamically allocated within rcl-layer, when DDS queue is accessed with rcl_wait_set_init()
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | Yes
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ *
+ * \param [inout] executor pointer to initialized executor
+ * \return `RCL_RET_OK` if executor prepare operation was successful
+ * \return `RCL_RET_INVALID_ARGUMENT` if any parameter is a null pointer
+ * \return `RCL_RET_ERROR` if any other error occured
+ */
+RCLC_PUBLIC
+rcl_ret_t
+rclc_executor_prepare(
+  rclc_executor_t * executor);
 
 /**
  *  The spin-some function checks one-time for new data from the DDS-queue.

--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -1082,11 +1082,11 @@ _rclc_let_scheduling(rclc_executor_t * executor)
 }
 
 rcl_ret_t
-rclc_executor_spin_some(rclc_executor_t * executor, const uint64_t timeout_ns)
+rclc_executor_prepare(rclc_executor_t * executor)
 {
   rcl_ret_t rc = RCL_RET_OK;
   RCL_CHECK_ARGUMENT_FOR_NULL(executor, RCL_RET_INVALID_ARGUMENT);
-  RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "spin_some");
+  RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "executor_prepare");
 
   // initialize wait_set if
   // (1) this is the first invocation of executor_spin_some()
@@ -1114,6 +1114,18 @@ rclc_executor_spin_some(rclc_executor_t * executor, const uint64_t timeout_ns)
       return rc;
     }
   }
+
+  return rc;
+}
+
+rcl_ret_t
+rclc_executor_spin_some(rclc_executor_t * executor, const uint64_t timeout_ns)
+{
+  rcl_ret_t rc = RCL_RET_OK;
+  RCL_CHECK_ARGUMENT_FOR_NULL(executor, RCL_RET_INVALID_ARGUMENT);
+  RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "spin_some");
+
+  rclc_executor_prepare(executor);
 
   // set rmw fields to NULL
   rc = rcl_wait_set_clear(&executor->wait_set);

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -2501,6 +2501,31 @@ TEST_F(TestDefaultExecutor, executor_test_guard_condition) {
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
 }
 
+TEST_F(TestDefaultExecutor, prepare_executor_test) {
+  rcl_ret_t rc;
+  rclc_executor_t executor;
+  executor = rclc_executor_get_zero_initialized_executor();
+  rc = rclc_executor_init(&executor, &this->context, 1, this->allocator_ptr);
+  EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
+
+  // initialize guard condition
+  rcl_guard_condition_t guard_cond = rcl_get_zero_initialized_guard_condition();
+  rc = rcl_guard_condition_init(
+    &guard_cond, &this->context, rcl_guard_condition_get_default_options());
+  EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
+
+  // prepare executor
+  rc = rclc_executor_prepare(&executor);
+  EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
+
+  // spin once
+  rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
+
+  // tear down
+  rc = rclc_executor_fini(&executor);
+  EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
+}
+
 TEST_F(TestDefaultExecutor, executor_test_remove_guard_condition) {
   // Test guard_condition.
   rcl_ret_t rc;

--- a/rclc_examples/src/example_client_node.c
+++ b/rclc_examples/src/example_client_node.c
@@ -75,6 +75,9 @@ int main(int argc, const char * const * argv)
   RCCHECK(rcl_send_request(&client, &req, &seq))
   printf("Send service request %ld + %ld.\n", req.a, req.b);
 
+  // Optional prepare for avoiding allocations during spin
+  rclc_executor_prepare(&executor);
+
   rclc_executor_spin(&executor);
 
   RCCHECK(rcl_client_fini(&client, &node));

--- a/rclc_examples/src/example_executor.c
+++ b/rclc_examples/src/example_executor.c
@@ -184,6 +184,9 @@ int main(int argc, const char * argv[])
     printf("Error in rclc_executor_add_timer.\n");
   }
 
+  // Optional prepare for avoiding allocations during spin
+  rclc_executor_prepare(&executor);
+
   for (unsigned int i = 0; i < 10; i++) {
     // timeout specified in ns (here 1s)
     rclc_executor_spin_some(&executor, 1000 * (1000 * 1000));

--- a/rclc_examples/src/example_executor_convenience.c
+++ b/rclc_examples/src/example_executor_convenience.c
@@ -154,6 +154,9 @@ int main(int argc, const char * argv[])
     printf("Error in rclc_executor_add_timer.\n");
   }
 
+  // Optional prepare for avoiding allocations during spin
+  rclc_executor_prepare(&executor);
+
   for (unsigned int i = 0; i < 10; i++) {
     // timeout specified in nanoseconds (here 1s)
     rclc_executor_spin_some(&executor, 1000 * (1000 * 1000));

--- a/rclc_examples/src/example_parameter_server.c
+++ b/rclc_examples/src/example_parameter_server.c
@@ -106,6 +106,9 @@ int main()
     rclc_parameter_get_int(&param_server, "param2", &param2);
     rclc_parameter_get_double(&param_server, "param3", &param3);
 
+    // Optional prepare for avoiding allocations during spin
+    rclc_executor_prepare(&executor);
+
     rclc_executor_spin(&executor);
 
     // clean up

--- a/rclc_examples/src/example_service_node.c
+++ b/rclc_examples/src/example_service_node.c
@@ -73,6 +73,9 @@ int main(int argc, const char * const * argv)
 
   RCCHECK(rclc_executor_add_service(&executor, &service, &req, &res, service_callback));
 
+  // Optional prepare for avoiding allocations during spin
+  rclc_executor_prepare(&executor);
+
   rclc_executor_spin(&executor);
 
   RCCHECK(rcl_service_fini(&service, &node));


### PR DESCRIPTION
Separated function for executor prepares so users interested in avoiding dynamic allocation during spin time can call this function before. During the spin, the function will do not nothing if the wait set it valid.

Closes https://github.com/ros2/rclc/issues/114