### PR TITLE
rolling: updated codecov in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,12 @@ jobs:
         package-name: "rclc rclc_examples rclc_lifecycle rclc_parameter"
         vcs-repo-file-url: dependencies.repos
         target-ros2-distro: ${{ matrix.ros_distribution }}
-        colcon-mixin-name: coverage-gcc
+        colcon-defaults: |
+          {
+            "build": {
+              "mixin": [ "coverage-gcc" ]
+            }
+          }
         colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
     - uses: codecov/codecov-action@v1
       with:


### PR DESCRIPTION
noticed warning from CI build job on Rolling:
https://github.com/ros2/rclc/runs/3084798829?check_suite_focus=true

```C

Warning: Unexpected input(s) 'colcon-mixin-name', valid inputs are ['colcon-defaults', 'colcon-mixin-repository', 'coverage-ignore-pattern', 'extra-cmake-args', 'colcon-extra-args', 'import-token', 'package-name', 'target-ros1-distro', 'target-ros2-distro', 'vcs-repo-file-url']

Run ros-tooling/action-ros-ci@0.2.1
/usr/bin/docker exec  f120bd8cd6407a6dbf8e8109076c02b2acea0fb4eb1c8ea7b4aa4b03303a6242 sh -c "cat /etc/*release | grep ^ID"
```
replaced codecov configuration with the one in Galactic.