### PR TITLE
Fix codecov to ignore unit tests and rclc_examples package

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
 ignore:
-  - "ros_ws/src/**/rclc/test/**/*"
-  - "ros_ws/src/**/rclc_examples/**/*"
-  - "ros_ws/src/**/rclc_lifecycle/test/**/*"
-  - "ros_ws/src/**/rclc_parameter/test/**/*"
+  - "ros_ws/src/**/rclc/rclc/test/**/*"
+  - "ros_ws/src/**/rclc/rclc_examples/**/*"
+  - "ros_ws/src/**/rclc/rclc_lifecycle/test/**/*"
+  - "ros_ws/src/**/rclc/rclc_parameter/test/**/*"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
 fixes:
-  - "ros_ws/src/*/::"
+  - "ros_ws/src/*/rclc::"
 
 ignore:
   - "rclc_examples/**/*"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,7 @@
+fixes:
+  - "ros_ws/src/*/rclc::"
 ignore:
-  - "ros_ws/src/**/rclc/rclc/test/**/*"
-  - "ros_ws/src/**/rclc/rclc_examples/**/*"
-  - "ros_ws/src/**/rclc/rclc_lifecycle/test/**/*"
-  - "ros_ws/src/**/rclc/rclc_parameter/test/**/*"
+  - "rclc/test/**/*"
+  - "rclc_examples/**/*"
+  - "rclc_lifecycle/test/*"
+  - "rclc_parameter/test/**/*"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
+fixes:
+  - "ros_ws/src/*/::"
+
 ignore:
   - "rclc_examples/**/*"
   - "rclc/test/**/*"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,5 @@
-fixes:
-  - "ros_ws/src/*/rclc::"
-
 ignore:
-  - "rclc_examples/**/*"
-  - "rclc/test/**/*"
-  - "rclc_lifecycle/test/**/*"
-  - "rclc_parameter/test/**/*"
+  - "ros_ws/src/**/rclc/test/**/*"
+  - "ros_ws/src/**/rclc_examples/**/*"
+  - "ros_ws/src/**/rclc_lifecycle/test/**/*"
+  - "ros_ws/src/**/rclc_parameter/test/**/*"

--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -106,10 +106,10 @@ rclc_executor_init(
     return RCL_RET_INVALID_ARGUMENT;
   }
 
-  int x = 0;
+  rcl_ret_t ret = RCL_RET_OK;
   // just a test
   if (executor == NULL) {
-    x = 1;
+    ret = RCL_RET_INVALID_ARGUMENT;
   }
 
   rcl_ret_t ret = RCL_RET_OK;

--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -28,7 +28,6 @@
 // default timeout for rcl_wait() is 1000ms
 #define DEFAULT_WAIT_TIMEOUT_NS 1000000000
 
-
 // declarations of helper functions
 /*
 /// get new data from DDS queue for handle i
@@ -107,10 +106,6 @@ rclc_executor_init(
   }
 
   rcl_ret_t ret = RCL_RET_OK;
-  // just a test
-  if (executor == NULL) {
-    ret = RCL_RET_INVALID_ARGUMENT;
-  }
 
   (*executor) = rclc_executor_get_zero_initialized_executor();
   executor->context = context;

--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -106,6 +106,12 @@ rclc_executor_init(
     return RCL_RET_INVALID_ARGUMENT;
   }
 
+  int x = 0;
+  // just a test
+  if (executor == NULL) {
+    x = 1;
+  }
+
   rcl_ret_t ret = RCL_RET_OK;
   (*executor) = rclc_executor_get_zero_initialized_executor();
   executor->context = context;

--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -28,6 +28,7 @@
 // default timeout for rcl_wait() is 1000ms
 #define DEFAULT_WAIT_TIMEOUT_NS 1000000000
 
+
 // declarations of helper functions
 /*
 /// get new data from DDS queue for handle i

--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -106,7 +106,6 @@ rclc_executor_init(
   }
 
   rcl_ret_t ret = RCL_RET_OK;
-
   (*executor) = rclc_executor_get_zero_initialized_executor();
   executor->context = context;
   executor->max_handles = number_of_handles;

--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -112,7 +112,6 @@ rclc_executor_init(
     ret = RCL_RET_INVALID_ARGUMENT;
   }
 
-  rcl_ret_t ret = RCL_RET_OK;
   (*executor) = rclc_executor_get_zero_initialized_executor();
   executor->context = context;
   executor->max_handles = number_of_handles;


### PR DESCRIPTION
test folders should be ignored in the codecov analysis.

root file path in codecov contains a random number, this needs to be fixed. See:
https://docs.codecov.com/docs/fixing-paths

Answer from codecov team: (2021-07-28):
 
This isn't working because the path of your files is `/ros_ws/src/28ud84ktfbl/rclc`, if you check that link you shared.  You will nead a path fix rule to ajust this so the patch matches your repo https://docs.codecov.com/docs/fixing-paths, or add that prefix to your ignore rules.

Ticket: https://codecov.freshdesk.com/helpdesk/tickets/5626

Best,

Joe Becher (she/her)
Lead Support Engineer | Codecov
