### PR TITLE
 updated rcl dependency to galactic

### DIFF
--- a/dependencies.repos
+++ b/dependencies.repos
@@ -1,4 +1,4 @@
 - git:
     local-name: rcl
     uri: https://github.com/ros2/rcl.git
-    version: master
+    version: galactic


### PR DESCRIPTION
See https://github.com/ros2/rcl/commit/4296dd1e94c444e4fca8b76a638eba80de27614d#commitcomment-54845498

Dependency on rcl on Galactic should be galactic not master.
FYI @norro