### PR TITLE
use-ros2-testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ros-tooling/setup-ros@0.2.1
       with:
+        use-ros2-testing: true
         required-ros-distributions: ${{ matrix.ros_distribution }}
     - name : Download and install rclc-dependencies
       run: |


### PR DESCRIPTION
See https://github.com/ros2/rcl/commit/4296dd1e94c444e4fca8b76a638eba80de27614d
There was an update on rcl , but the CI job on Github did not sync with these changes (here dependency on `rcl` and `tracetools`)

Solution: `use-ros2-testing=true`