### PR TITLE
[foxy] feature allows change of message pointer

### DIFF
--- a/rclc/include/rclc/executor.h
+++ b/rclc/include/rclc/executor.h
@@ -527,6 +527,9 @@ _rclc_executor_change_message_by_handle(
  *  Locates the first subscription handle carrying the old_message pointer
  *  and replaces its message with the new_message pointer,
  *  the new message pointer must be initialised and allocated
+ * * this should only be used during the subscription callback, or between calls to spin()
+ *   calling this at other times risks discarding data from the rmw and running
+ *     the callback with new_message empty
  * * An error is returned if old_message is not found in the handles of the executor.
  *
  * <hr>
@@ -559,6 +562,9 @@ rclc_executor_swap_subscription_message(
  *  Locates the first client handle carrying the old_response pointer
  *  and replaces its message with the new_response pointer,
  *  the new message pointer must be initialised and allocated
+ * * this should only be used during the client callback, or between calls to spin()
+ *   calling this at other times risks discarding data from the rmw and running
+ *     the callback with new_response empty
  * * An error is returned if old_response is not found in the handles of the executor.
  *
  * <hr>
@@ -591,6 +597,9 @@ rclc_executor_swap_client_response(
  *  Locates the first service handle carrying the old_request pointer
  *  and replaces its message with the new_request pointer,
  *  the new message pointer must be initialised and allocated
+ * * this should only be used during the service callback, or between calls to spin()
+ *   calling this at other times risks discarding data from the rmw and running
+ *     the callback with new_request empty
  * * An error is returned if old_request is not found in the handles of the executor.
  *
  * <hr>

--- a/rclc/include/rclc/executor.h
+++ b/rclc/include/rclc/executor.h
@@ -521,6 +521,110 @@ _rclc_executor_change_message_by_handle(
   void * new_message,
   void ** search_cache);
 
+/**
+ *  substitute a message pointer used in subscription callbacks, located by rcl handle
+ *  Locates the first subscription handle carrying the subscription pointer
+ *  and replaces its message with the new_message pointer,
+ *  the new message pointer must be initialised and allocated
+ * * this should only be used during the subscription callback, or between calls to spin()
+ *   calling this at other times risks discarding data from the rmw and running
+ *     the callback with new_message empty
+ * * An error is returned if subscription is not found in the handles of the executor.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param [inout] executor pointer to initialized executor
+ * \param [in] subscription pointer to rcl subscription used in rclc_executor_add_subscription
+ * \param [in] new_message pointer to a replacement message pointer
+ * \param [inout] search_cache a pointer to a user-held pointer to reduce time spent searching (may be NULL)
+ * \return `RCL_RET_OK` if message substitution was successful
+ * \return `RCL_RET_INVALID_ARGUMENT` if executor, subscription, or new_message is a null pointer
+ * \return `RCL_RET_ERROR` if the subscription is not found
+ */
+RCLC_PUBLIC
+rcl_ret_t
+rclc_executor_change_subscription_message(
+  rclc_executor_t * executor,
+  const rcl_subscription_t * subscription,
+  void * new_message,
+  void ** search_cache);
+
+
+/**
+ *  substitute a message pointer used in client callbacks, located by rcl handle
+ *  Locates the first client handle carrying the client pointer
+ *  and replaces its message with the new_response pointer,
+ *  the new message pointer must be initialised and allocated
+ * * this should only be used during the client callback, or between calls to spin()
+ *   calling this at other times risks discarding data from the rmw and running
+ *     the callback with new_response empty
+ * * An error is returned if client is not found in the handles of the executor.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param [inout] executor pointer to initialized executor
+ * \param [in] client pointer the rcl client used in rclc_executor_add_client
+ * \param [in] new_response pointer to a replacement message pointer
+ * \param [inout] search_cache a pointer to a user-held pointer to reduce time spent searching (may be NULL)
+ * \return `RCL_RET_OK` if message substitution was successful
+ * \return `RCL_RET_INVALID_ARGUMENT` if executor, client, or new_message is a null pointer
+ * \return `RCL_RET_ERROR` if the client is not found
+ */
+RCLC_PUBLIC
+rcl_ret_t
+rclc_executor_change_client_response(
+  rclc_executor_t * executor,
+  const rcl_client_t * client,
+  void * new_response,
+  void ** search_cache);
+
+
+/**
+ *  substitute a message pointer used in service callbacks, located by rcl handle
+ *  Locates the first service handle carrying the service pointer
+ *  and replaces its message with the new_request pointer,
+ *  the new message pointer must be initialised and allocated
+ * * this should only be used during the service callback, or between calls to spin()
+ *   calling this at other times risks discarding data from the rmw and running
+ *     the callback with new_request empty
+ * * An error is returned if service is not found in the handles of the executor.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param [inout] executor pointer to initialized executor
+ * \param [in] service pointer to a rcl service used in rclc_executor_add_service
+ * \param [in] new_request pointer to a replacement message pointer
+ * \param [inout] search_cache a pointer to a user-held pointer to reduce time spent searching (may be NULL)
+ * \return `RCL_RET_OK` if message substitution was successful
+ * \return `RCL_RET_INVALID_ARGUMENT` if executor, service, or new_message is a null pointer
+ * \return `RCL_RET_ERROR` if the service is not found
+ */
+RCLC_PUBLIC
+rcl_ret_t
+rclc_executor_change_service_request(
+  rclc_executor_t * executor,
+  const rcl_service_t * service,
+  void * new_request,
+  void ** search_cache);
+
 
 /**
  *  substitute a message pointer used in subscription callbacks, located by message pointer

--- a/rclc/include/rclc/executor.h
+++ b/rclc/include/rclc/executor.h
@@ -485,6 +485,140 @@ rclc_executor_add_guard_condition(
 
 
 /**
+ *  substitute a message pointer used in callbacks, located by rcl_handle
+ *  Locates the first executor->handle carrying rcl_handle and matching handle_type,
+ *   and replaces the allocated message in executor->handle->data
+ *
+ *  if search_cache is not NULL, it will be updated to point to the relevant rclc executor handle.
+ *   The actual value of search_cache is not intended to be used except for this function
+ *    and will be invalid after any call that removes a handle from the executor
+ *  this function assumes that rcl_handle is unique in the executor,
+ *   and will change the message of the first matching handle
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param [inout] executor pointer to initialized executor
+ * \param [in] handle_type a rclc_executor_handle_type_t used to enforce type safety
+ * \param [in] rcl_handle pointer to the rcl_handle the subscription was initiliased around
+ * \param [in] new_message function pointer to a callback function
+ * \param [inout] search_cache a pointer to a user-held pointer indicating where to search first.
+ * \return `RCL_RET_OK` if message substitution was successful
+ * \return `RCL_RET_INVALID_ARGUMENT` if executor, rcl_handle, or new_message is a null pointer
+ * \return `RCL_RET_ERROR` if any other error occured
+ */
+RCLC_LOCAL
+rcl_ret_t
+_rclc_executor_change_message_by_handle(
+  rclc_executor_t * executor,
+  rclc_executor_handle_type_t handle_type,
+  const void * rcl_handle,
+  void * new_message,
+  void ** search_cache);
+
+
+/**
+ *  substitute a message pointer used in subscription callbacks, located by message pointer
+ *  Locates the first subscription handle carrying the old_message pointer
+ *  and replaces its message with the new_message pointer,
+ *  the new message pointer must be initialised and allocated
+ * * An error is returned if old_message is not found in the handles of the executor.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param [inout] executor pointer to initialized executor
+ * \param [in] old_message pointer to a message held by a subscription
+ * \param [in] new_message pointer to a replacement message pointer
+ * \param [inout] search_cache a pointer to a user-held pointer to reduce time spent searching (may be NULL)
+ * \return `RCL_RET_OK` if message substitution was successful
+ * \return `RCL_RET_INVALID_ARGUMENT` if executor, old_message, or new_message is a null pointer
+ * \return `RCL_RET_ERROR` if the old_message is not found
+ */
+RCLC_PUBLIC
+rcl_ret_t
+rclc_executor_swap_subscription_message(
+  rclc_executor_t * executor,
+  const void * old_message,
+  void * new_message,
+  void ** search_cache);
+
+
+/**
+ *  substitute a message pointer used in client callbacks, located by message pointer
+ *  Locates the first client handle carrying the old_response pointer
+ *  and replaces its message with the new_response pointer,
+ *  the new message pointer must be initialised and allocated
+ * * An error is returned if old_response is not found in the handles of the executor.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param [inout] executor pointer to initialized executor
+ * \param [in] old_response pointer to a message held by a client
+ * \param [in] new_response pointer to a replacement message pointer
+ * \param [inout] search_cache a pointer to a user-held pointer to reduce time spent searching (may be NULL)
+ * \return `RCL_RET_OK` if message substitution was successful
+ * \return `RCL_RET_INVALID_ARGUMENT` if executor, old_message, or new_message is a null pointer
+ * \return `RCL_RET_ERROR` if the old_message is not found
+ */
+RCLC_PUBLIC
+rcl_ret_t
+rclc_executor_swap_client_response(
+  rclc_executor_t * executor,
+  const void * old_response,
+  void * new_response,
+  void ** search_cache);
+
+
+/**
+ *  substitute a message pointer used in service callbacks, located by message pointer
+ *  Locates the first service handle carrying the old_request pointer
+ *  and replaces its message with the new_request pointer,
+ *  the new message pointer must be initialised and allocated
+ * * An error is returned if old_request is not found in the handles of the executor.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param [inout] executor pointer to initialized executor
+ * \param [in] old_request pointer to a message held by service
+ * \param [in] new_request pointer to a replacement message pointer
+ * \param [inout] search_cache a pointer to a user-held pointer to reduce time spent searching (may be NULL)
+ * \return `RCL_RET_OK` if message substitution was successful
+ * \return `RCL_RET_INVALID_ARGUMENT` if executor, old_message, or new_message is a null pointer
+ * \return `RCL_RET_ERROR` if the old_message is not found
+ */
+RCLC_PUBLIC
+rcl_ret_t
+rclc_executor_swap_service_request(
+  rclc_executor_t * executor,
+  const void * old_request,
+  void * new_request,
+  void ** search_cache);
+
+
+/**
  *  Removes a subscription from an executor.
  * * An error is returned if {@link rclc_executor_t.handles} array is empty.
  * * An error is returned if subscription is not found in {@link rclc_executor_t.handles}.

--- a/rclc/include/rclc/executor_handle.h
+++ b/rclc/include/rclc/executor_handle.h
@@ -177,6 +177,27 @@ typedef struct
   size_t number_of_events;
 } rclc_executor_handle_counters_t;
 
+
+/**
+ *
+ * A convenience function that reduces values of rclc_executor_handle_type_t
+ *   to an essential sub-set of rclc_executor_handle_type_t
+ *  example: SERVICE_WITH_REQUEST_ID and SERVICE_WITH_CONTEXT becomes simply SERVICE.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | Yes
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] full_type the full range of rclc_executor_handle_type_t
+ * \return the subset of rclc_executor_handle_type_t that has relevance to rcl
+ */
+rclc_executor_handle_type_t
+rclc_executor_handle_reduced_type(const rclc_executor_handle_type_t full_type);
+
 /**
  * Initializes the counters of each handle type to zero.
  *

--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -907,7 +907,7 @@ rclc_executor_swap_service_request(
  *   deduplicate _rclc_executor_find_handle and _rclc_executor_find_handle_by_message
  *   before implementing rclc_executor_swap_service_response
  * alternatively, see executor_handle.h for jst3si's suggestion of a rclc_service_data_type_t
- * the multiple indirection would make this
+ *   the multiple indirection would make this a bit redundant though
 rclc_executor_swap_service_response(
   rclc_executor_t * executor,
   const void * old_response,

--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -694,13 +694,12 @@ _rclc_executor_find_handle(
   void ** search_cache)
 {
   if (NULL == executor) {
-    // notionally unreachable,
-    //  calling function should protect with RCL_CHECK_ARGUMENT_FOR_NULL(executor)
     return NULL;
   }
 
   rclc_executor_handle_t * matching_handle = NULL;
   rclc_executor_handle_t * test_handle = NULL;
+  handle_type = rclc_executor_handle_reduced_type(handle_type);
 
   if (NULL != search_cache) {
     // bounds check search_cache before use
@@ -900,6 +899,42 @@ rclc_executor_swap_service_request(
     search_cache);
 }
 
+rcl_ret_t
+rclc_executor_change_subscription_message(
+  rclc_executor_t * executor,
+  const rcl_subscription_t * subscription,
+  void * new_message,
+  void ** search_cache)
+{
+  return _rclc_executor_change_message_by_handle(
+    executor, SUBSCRIPTION,
+    (const void *) subscription, new_message,
+    search_cache);
+}
+rcl_ret_t
+rclc_executor_change_client_response(
+  rclc_executor_t * executor,
+  const rcl_client_t * client,
+  void * new_response,
+  void ** search_cache)
+{
+  return _rclc_executor_change_message_by_handle(
+    executor, CLIENT,
+    (const void *) client, new_response,
+    search_cache);
+}
+rcl_ret_t
+rclc_executor_change_service_request(
+  rclc_executor_t * executor,
+  const rcl_service_t * service,
+  void * new_request,
+  void ** search_cache)
+{
+  return _rclc_executor_change_message_by_handle(
+    executor, SERVICE,
+    (const void *) service, new_request,
+    search_cache);
+}
 
 /*
  * TODO @BrettRD

--- a/rclc/src/rclc/executor_handle.c
+++ b/rclc/src/rclc/executor_handle.c
@@ -20,6 +20,44 @@
 #include <rcutils/logging_macros.h>
 
 
+// convenience function to deal with fluctuating number of handle types
+rclc_executor_handle_type_t
+rclc_executor_handle_reduced_type(const rclc_executor_handle_type_t full_type)
+{
+  rclc_executor_handle_type_t reduced_type;
+  switch (full_type) {
+    case NONE:
+      reduced_type = NONE;
+      break;
+    case SUBSCRIPTION:
+    case SUBSCRIPTION_WITH_CONTEXT:
+      reduced_type = SUBSCRIPTION;
+      break;
+    case TIMER:
+      // case TIMER_WITH_CONTEXT:
+      reduced_type = TIMER;
+      break;
+    case CLIENT:
+    case CLIENT_WITH_REQUEST_ID:
+      // case CLIENT_WITH_CONTEXT:
+      reduced_type = CLIENT;
+      break;
+    case SERVICE:
+    case SERVICE_WITH_REQUEST_ID:
+    case SERVICE_WITH_CONTEXT:
+      reduced_type = SERVICE;
+      break;
+    case GUARD_CONDITION:
+      // case GUARD_CONDITION_WITH_CONTEXT:
+      reduced_type = GUARD_CONDITION;
+      break;
+    default:
+      reduced_type = full_type;
+      break;
+  }
+  return reduced_type;
+}
+
 // initialization of handle_counters object
 rcl_ret_t
 rclc_executor_handle_counters_zero_init(rclc_executor_handle_counters_t * handle_counters)
@@ -83,30 +121,23 @@ rclc_executor_handle_print(rclc_executor_handle_t * handle)
 
   char * typeName;
 
-  switch (handle->type) {
+  switch (rclc_executor_handle_reduced_type(handle->type)) {
     case NONE:
       typeName = "None";
       break;
     case SUBSCRIPTION:
-    case SUBSCRIPTION_WITH_CONTEXT:
       typeName = "Sub";
       break;
     case TIMER:
-      // case TIMER_WITH_CONTEXT:
       typeName = "Timer";
       break;
     case CLIENT:
-    case CLIENT_WITH_REQUEST_ID:
-      // case CLIENT_WITH_CONTEXT:
       typeName = "Client";
       break;
     case SERVICE:
-    case SERVICE_WITH_REQUEST_ID:
-    case SERVICE_WITH_CONTEXT:
       typeName = "Service";
       break;
     case GUARD_CONDITION:
-      // case GUARD_CONDITION_WITH_CONTEXT:
       typeName = "GuardCondition";
       break;
     default:
@@ -127,27 +158,20 @@ rclc_executor_handle_get_ptr(rclc_executor_handle_t * handle)
   }
 
   void * ptr;
-  switch (handle->type) {
+  switch (rclc_executor_handle_reduced_type(handle->type)) {
     case SUBSCRIPTION:
-    case SUBSCRIPTION_WITH_CONTEXT:
       ptr = handle->subscription;
       break;
     case TIMER:
-      // case TIMER_WITH_CONTEXT:
       ptr = handle->timer;
       break;
     case CLIENT:
-    case CLIENT_WITH_REQUEST_ID:
-      // case CLIENT_WITH_CONTEXT:
       ptr = handle->client;
       break;
     case SERVICE:
-    case SERVICE_WITH_REQUEST_ID:
-    case SERVICE_WITH_CONTEXT:
       ptr = handle->service;
       break;
     case GUARD_CONDITION:
-      // case GUARD_CONDITION_WITH_CONTEXT:
       ptr = handle->gc;
       break;
     case NONE:

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -831,8 +831,6 @@ TEST_F(TestDefaultExecutor, executor_change_subscription_message) {
   rc = rclc_executor_change_subscription_message(
     &executor, &this->sub1, &this->sub1_msg, &search_cache);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
-  EXPECT_EQ(executor.info.number_of_subscriptions, num_subscriptions) <<
-    "number of subscriptions is expected to be unchanged";
   EXPECT_EQ(executor.handles[0].data, &this->sub1_msg) <<
     "message is expected to be unchanged";
   EXPECT_EQ(&(executor.handles[0]), search_cache) <<
@@ -842,8 +840,6 @@ TEST_F(TestDefaultExecutor, executor_change_subscription_message) {
   rc = rclc_executor_change_subscription_message(
     &executor, &this->sub1, &this->sub1_msg, NULL);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
-  EXPECT_EQ(executor.info.number_of_subscriptions, num_subscriptions) <<
-    "number of subscriptions is expected to be unchanged";
   EXPECT_EQ(executor.handles[0].data, &this->sub1_msg) <<
     "message is expected to be unchanged";
 
@@ -851,8 +847,6 @@ TEST_F(TestDefaultExecutor, executor_change_subscription_message) {
   rc = rclc_executor_change_subscription_message(
     &executor, &this->sub1, &this->sub3_msg, &search_cache);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
-  EXPECT_EQ(executor.info.number_of_subscriptions, num_subscriptions) <<
-    "number of subscriptions is expected to be unchanged";
   EXPECT_EQ(executor.handles[0].data, &this->sub3_msg) <<
     "message is expected to be replaced";
   EXPECT_EQ(&(executor.handles[0]), search_cache) <<
@@ -862,8 +856,6 @@ TEST_F(TestDefaultExecutor, executor_change_subscription_message) {
   rc = rclc_executor_change_subscription_message(
     &executor, &this->sub1, &this->sub1_msg, &search_cache);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
-  EXPECT_EQ(executor.info.number_of_subscriptions, num_subscriptions) <<
-    "number of subscriptions is expected to be unchanged";
   EXPECT_EQ(executor.handles[0].data, &this->sub1_msg) <<
     "message is expected to be restored";
 
@@ -871,8 +863,6 @@ TEST_F(TestDefaultExecutor, executor_change_subscription_message) {
   rc = rclc_executor_change_subscription_message(
     &executor, &this->sub2, &this->sub3_msg, &search_cache);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
-  EXPECT_EQ(executor.info.number_of_subscriptions, num_subscriptions) <<
-    "number of subscriptions is expected to be unchanged";
   EXPECT_EQ(executor.handles[1].data, &this->sub3_msg) <<
     "message is expected to be replaced";
   EXPECT_EQ(&(executor.handles[1]), search_cache) <<
@@ -882,34 +872,32 @@ TEST_F(TestDefaultExecutor, executor_change_subscription_message) {
   rc = rclc_executor_change_subscription_message(
     &executor, &this->sub2, &this->sub2_msg, &search_cache);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
-  EXPECT_EQ(executor.info.number_of_subscriptions, num_subscriptions) <<
-    "number of subscriptions is expected to be unchanged";
   EXPECT_EQ(executor.handles[1].data, &this->sub2_msg) <<
     "message is expected to be restored";
+
+  // test non-existant subscription for executor
+  rc = rclc_executor_change_subscription_message(
+    &executor, &this->sub3, &this->sub3_msg, &search_cache);
+  EXPECT_EQ(RCL_RET_ERROR, rc) << "changed message in non-existent handle";
+  rcutils_reset_error();
 
   // test NULL pointer for executor
   rc = rclc_executor_change_subscription_message(
     NULL, &this->sub1, &this->sub1_msg, &search_cache);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rc) << rcl_get_error_string().str;
   rcutils_reset_error();
-  EXPECT_EQ(executor.info.number_of_subscriptions, num_subscriptions) <<
-    "number of subscriptions is expected to be one";
 
   // test NULL pointer for rcl handle
   rc = rclc_executor_change_subscription_message(
     &executor, NULL, &this->sub1_msg, &search_cache);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rc) << rcl_get_error_string().str;
   rcutils_reset_error();
-  EXPECT_EQ(executor.info.number_of_subscriptions, num_subscriptions) <<
-    "number of subscriptions is expected to be one";
 
   // test NULL pointer for new message
   rc = rclc_executor_change_subscription_message(
     &executor, &this->sub1, NULL, &search_cache);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rc) << rcl_get_error_string().str;
   rcutils_reset_error();
-  EXPECT_EQ(executor.info.number_of_subscriptions, num_subscriptions) <<
-    "number of subscriptions is expected to be one";
 
   // tear down
   rc = rclc_executor_fini(&executor);
@@ -945,8 +933,6 @@ TEST_F(TestDefaultExecutor, executor_swap_subscription_message) {
   rc = rclc_executor_swap_subscription_message(
     &executor, &this->sub1_msg, &this->sub1_msg, &search_cache);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
-  EXPECT_EQ(executor.info.number_of_subscriptions, num_subscriptions) <<
-    "number of subscriptions is expected to be unchanged";
   EXPECT_EQ(executor.handles[0].data, &this->sub1_msg) <<
     "message is expected to be unchanged";
   EXPECT_EQ(&(executor.handles[0]), search_cache) <<
@@ -956,8 +942,6 @@ TEST_F(TestDefaultExecutor, executor_swap_subscription_message) {
   rc = rclc_executor_swap_subscription_message(
     &executor, &this->sub1_msg, &this->sub1_msg, NULL);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
-  EXPECT_EQ(executor.info.number_of_subscriptions, num_subscriptions) <<
-    "number of subscriptions is expected to be unchanged";
   EXPECT_EQ(executor.handles[0].data, &this->sub1_msg) <<
     "message is expected to be unchanged";
 
@@ -965,8 +949,6 @@ TEST_F(TestDefaultExecutor, executor_swap_subscription_message) {
   rc = rclc_executor_swap_subscription_message(
     &executor, &this->sub1_msg, &this->sub3_msg, &search_cache);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
-  EXPECT_EQ(executor.info.number_of_subscriptions, num_subscriptions) <<
-    "number of subscriptions is expected to be unchanged";
   EXPECT_EQ(executor.handles[0].data, &this->sub3_msg) <<
     "message is expected to be replaced";
   EXPECT_EQ(&(executor.handles[0]), search_cache) <<
@@ -976,8 +958,6 @@ TEST_F(TestDefaultExecutor, executor_swap_subscription_message) {
   rc = rclc_executor_swap_subscription_message(
     &executor, &this->sub3_msg, &this->sub1_msg, &search_cache);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
-  EXPECT_EQ(executor.info.number_of_subscriptions, num_subscriptions) <<
-    "number of subscriptions is expected to be unchanged";
   EXPECT_EQ(executor.handles[0].data, &this->sub1_msg) <<
     "message is expected to be restored";
 
@@ -985,8 +965,6 @@ TEST_F(TestDefaultExecutor, executor_swap_subscription_message) {
   rc = rclc_executor_swap_subscription_message(
     &executor, &this->sub2_msg, &this->sub3_msg, &search_cache);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
-  EXPECT_EQ(executor.info.number_of_subscriptions, num_subscriptions) <<
-    "number of subscriptions is expected to be unchanged";
   EXPECT_EQ(executor.handles[1].data, &this->sub3_msg) <<
     "message is expected to be replaced";
   EXPECT_EQ(&(executor.handles[1]), search_cache) <<
@@ -996,34 +974,32 @@ TEST_F(TestDefaultExecutor, executor_swap_subscription_message) {
   rc = rclc_executor_swap_subscription_message(
     &executor, &this->sub3_msg, &this->sub2_msg, &search_cache);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
-  EXPECT_EQ(executor.info.number_of_subscriptions, num_subscriptions) <<
-    "number of subscriptions is expected to be unchanged";
   EXPECT_EQ(executor.handles[1].data, &this->sub2_msg) <<
     "message is expected to be restored";
+
+  // try message that isn't in the executor
+  rc = rclc_executor_swap_subscription_message(
+    &executor, &this->sub3_msg, &this->sub2_msg, &search_cache);
+  EXPECT_EQ(RCL_RET_ERROR, rc) << "expected to fail with message not found";
+  rcutils_reset_error();
 
   // test NULL pointer for executor
   rc = rclc_executor_swap_subscription_message(
     NULL, &this->sub1_msg, &this->sub1_msg, &search_cache);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rc) << rcl_get_error_string().str;
   rcutils_reset_error();
-  EXPECT_EQ(executor.info.number_of_subscriptions, num_subscriptions) <<
-    "number of subscriptions is expected to be one";
 
   // test NULL pointer for old message
   rc = rclc_executor_swap_subscription_message(
     &executor, NULL, &this->sub1_msg, &search_cache);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rc) << rcl_get_error_string().str;
   rcutils_reset_error();
-  EXPECT_EQ(executor.info.number_of_subscriptions, num_subscriptions) <<
-    "number of subscriptions is expected to be one";
 
   // test NULL pointer for new message
   rc = rclc_executor_swap_subscription_message(
     &executor, &this->sub1_msg, NULL, &search_cache);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rc) << rcl_get_error_string().str;
   rcutils_reset_error();
-  EXPECT_EQ(executor.info.number_of_subscriptions, num_subscriptions) <<
-    "number of subscriptions is expected to be one";
 
   // tear down
   rc = rclc_executor_fini(&executor);

--- a/rclc/test/rclc/test_executor_handle.cpp
+++ b/rclc/test/rclc/test_executor_handle.cpp
@@ -19,12 +19,59 @@
 TEST(Test, executor_handle_reduced_type) {
   rclc_executor_handle_type_t full_type;
   rclc_executor_handle_type_t reduced_type;
+
+  // This test needs to cover unknown-unknown cases like new types,
+  //  and new types with assigned values
+  //  so we can't rely on simple exhaustive testing
+
+  // property tests
+
+  // test strict idempotency for all cases
   for (int i = -10; i < 30; i++) {
     full_type = (rclc_executor_handle_type_t) i;
     reduced_type = rclc_executor_handle_reduced_type(full_type);
     EXPECT_EQ(reduced_type, rclc_executor_handle_reduced_type(reduced_type)) <<
       "idempotency violation";
   }
+
+  // test pass-through in default case
+  for (int i = -10; i < 0; i++) {
+    full_type = (rclc_executor_handle_type_t) i;
+    EXPECT_EQ(full_type, rclc_executor_handle_reduced_type(full_type)) <<
+      "default case is not pass-through";
+  }
+
+  // implementation tests
+
+  // test known pass-though types
+  EXPECT_EQ(rclc_executor_handle_reduced_type(SUBSCRIPTION), SUBSCRIPTION) <<
+    "SUBSCRIPTION";
+  EXPECT_EQ(rclc_executor_handle_reduced_type(TIMER), TIMER) <<
+    "TIMER";
+  EXPECT_EQ(rclc_executor_handle_reduced_type(CLIENT), CLIENT) <<
+    "CLIENT";
+  EXPECT_EQ(rclc_executor_handle_reduced_type(SERVICE), SERVICE) <<
+    "SERVICE";
+  EXPECT_EQ(rclc_executor_handle_reduced_type(GUARD_CONDITION), GUARD_CONDITION) <<
+    "GUARD_CONDITION";
+  EXPECT_EQ(rclc_executor_handle_reduced_type(NONE), NONE) <<
+    "NONE";
+
+  // test known transformed types
+  EXPECT_EQ(rclc_executor_handle_reduced_type(SUBSCRIPTION_WITH_CONTEXT), SUBSCRIPTION) <<
+    "SUBSCRIPTION_WITH_CONTEXT";
+  EXPECT_EQ(rclc_executor_handle_reduced_type(CLIENT_WITH_REQUEST_ID), CLIENT) <<
+    "CLIENT_WITH_REQUEST_ID";
+  EXPECT_EQ(rclc_executor_handle_reduced_type(SERVICE_WITH_REQUEST_ID), SERVICE) <<
+    "SERVICE_WITH_REQUEST_ID";
+  EXPECT_EQ(rclc_executor_handle_reduced_type(SERVICE_WITH_CONTEXT), SERVICE) <<
+    "SERVICE_WITH_CONTEXT";
+  // EXPECT_EQ(rclc_executor_handle_reduced_type(TIMER_WITH_CONTEXT), TIMER) <<
+  //   "TIMER_WITH_CONTEXT";  // TODO";
+  // EXPECT_EQ(rclc_executor_handle_reduced_type(CLIENT_WITH_CONTEXT), CLIENT) <<
+  //   "CLIENT_WITH_CONTEXT";  // TODO";
+  // EXPECT_EQ(rclc_executor_handle_reduced_type(GUARD_CONDITION_WITH_CONTEXT), GUARD_CONDITION) <<
+  //   "GUARD_CONDITION_WITH_CONTEXT";  //TODO
 }
 
 TEST(Test, executor_handle_counters_zero_init) {

--- a/rclc/test/rclc/test_executor_handle.cpp
+++ b/rclc/test/rclc/test_executor_handle.cpp
@@ -16,6 +16,16 @@
 #include <gtest/gtest.h>
 #include "rclc/executor_handle.h"
 
+TEST(Test, executor_handle_reduced_type) {
+  rclc_executor_handle_type_t full_type;
+  rclc_executor_handle_type_t reduced_type;
+  for (int i = -10; i < 30; i++) {
+    full_type = (rclc_executor_handle_type_t) i;
+    reduced_type = rclc_executor_handle_reduced_type(full_type);
+    EXPECT_EQ(reduced_type, rclc_executor_handle_reduced_type(reduced_type)) <<
+      "idempotency violation";
+  }
+}
 
 TEST(Test, executor_handle_counters_zero_init) {
   rcl_ret_t rc;


### PR DESCRIPTION
**Following https://github.com/ros2/rclc/issues/186 This PR adds:**
 * the ability to change most message pointers passed into callbacks (useful for queues of complex pre-allocated messages)
 * a little bit more type safety to `rclc_executor_remove_subscription()`
 * a convenience function to reduce diff sizes when implementing `rclc_executor_add_client_with_context` and `rclc_executor_add_guard_condition_with_context`

**API additions:**
replace a message pointer  when only the message pointer is known (useful for context-free callbacks)
 * `rclc_executor_swap_subscription_message`
 * `rclc_executor_swap_client_response`
 * `rclc_executor_swap_service_request`

change a message pointer when the rcl handle is known (preferred)
 * `rclc_executor_change_subscription_message`
 * `rclc_executor_change_client_response`
 * `rclc_executor_change_service_request`

**Omissions:**
`rclc_executor_swap_service_response` requires slightly different machinery, and will be left out of this pull request

**Remaining work:**
~~The doc strings need adjustments~~ to show some thread-safety caveats (run during respective callbacks or not during spin)
~~The tests still need writing, as do regression tests~~ to demonstrate the previous type-safety flaw 
previously:
```
rclc_executor_t executor;
rcl_timer_t timer;
rclc_executor_add_timer(&executor, &timer);
rclc_executor_remove_subscription(&executor, &timer); 
// the last line returns ok, removes the timer handle, and decrements the subscription count
```
after writing this, I've realised that similar performance can come from changing only the variable-sized parts of a message without needing to interact with the executor, but this API still has some utility for complex nested messages

