### PR TITLE
Fix: printf in executor spin

### DIFF
--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -1350,7 +1350,10 @@ rclc_executor_spin(rclc_executor_t * executor)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(executor, RCL_RET_INVALID_ARGUMENT);
   rcl_ret_t ret = RCL_RET_OK;
-  printf("INFO: rcl_wait timeout %ld ms\n", ((executor->timeout_ns / 1000) / 1000));
+  RCUTILS_LOG_DEBUG_NAMED(
+    ROS_PACKAGE_NAME,
+    "INFO: rcl_wait timeout %ld ms",
+    ((executor->timeout_ns / 1000) / 1000));
   while (true) {
     ret = rclc_executor_spin_some(executor, executor->timeout_ns);
     if (!((ret == RCL_RET_OK) || (ret == RCL_RET_TIMEOUT))) {


### PR DESCRIPTION
This `printf` in `executor_spin` function will break multiple embedded use cases of micro-ROS in platforms where `printf` is not implemented by the hardware abstraction layer.

Changing it to a RCUTILS macro.