### PR TITLE
Fix init options handling

### DIFF
--- a/rclc/src/rclc/init.c
+++ b/rclc/src/rclc/init.c
@@ -64,6 +64,7 @@ rclc_support_init_with_options(
     allocator, "allocator is a null pointer", return RCL_RET_INVALID_ARGUMENT);
   rcl_ret_t rc = RCL_RET_OK;
 
+  support->init_options = rcl_get_zero_initialized_init_options();
   rcl_init_options_copy(init_options, &support->init_options);
 
   support->context = rcl_get_zero_initialized_context();

--- a/rclc/src/rclc/init.c
+++ b/rclc/src/rclc/init.c
@@ -43,7 +43,9 @@ rclc_support_init(
   }
 
   rc = rclc_support_init_with_options(support, argc, argv, &init_options, allocator);
-  rcl_init_options_fini(&init_options);
+  if (rcl_init_options_fini(&init_options) != RCL_RET_OK) {
+    PRINT_RCLC_ERROR(rclc_support_init, rcl_init_options_fini);
+  }
 
   return rc;
 }

--- a/rclc/src/rclc/init.c
+++ b/rclc/src/rclc/init.c
@@ -67,7 +67,11 @@ rclc_support_init_with_options(
   rcl_ret_t rc = RCL_RET_OK;
 
   support->init_options = rcl_get_zero_initialized_init_options();
-  rcl_init_options_copy(init_options, &support->init_options);
+  rc = rcl_init_options_copy(init_options, &support->init_options);
+  if (rc != RCL_RET_OK) {
+    PRINT_RCLC_ERROR(rclc_init, rcl_init_options_copy);
+    return rc;
+  }
 
   support->context = rcl_get_zero_initialized_context();
   rc = rcl_init(argc, argv, &support->init_options, &support->context);

--- a/rclc/src/rclc/init.c
+++ b/rclc/src/rclc/init.c
@@ -43,6 +43,7 @@ rclc_support_init(
   }
 
   rc = rclc_support_init_with_options(support, argc, argv, &init_options, allocator);
+  rcl_init_options_fini(&init_options);
 
   return rc;
 }
@@ -63,7 +64,7 @@ rclc_support_init_with_options(
     allocator, "allocator is a null pointer", return RCL_RET_INVALID_ARGUMENT);
   rcl_ret_t rc = RCL_RET_OK;
 
-  memcpy(&support->init_options, init_options, sizeof(rcl_init_options_t));
+  rcl_init_options_copy(init_options, &support->init_options);
 
   support->context = rcl_get_zero_initialized_context();
   rc = rcl_init(argc, argv, &support->init_options, &support->context);


### PR DESCRIPTION
RMW init options may allocate memory, so a simple memcpy may result in allocated memory used in two different rcl_init_option_t structs simultaneously.