### PR TITLE
Remove init options from support

### DIFF
--- a/rclc/README.md
+++ b/rclc/README.md
@@ -547,7 +547,6 @@ the parameters used in multiple RCL initialization functions:
 ```C
 typedef struct
 {
-  rcl_init_options_t init_options;
   rcl_context_t context;
   rcl_allocator_t * allocator;
   rcl_clock_t clock;

--- a/rclc/include/rclc/types.h
+++ b/rclc/include/rclc/types.h
@@ -22,14 +22,12 @@ extern "C"
 {
 #endif
 
-#include <rcl/init_options.h>
 #include <rcl/context.h>
 #include <rcl/allocator.h>
 #include <rcl/time.h>
 
 typedef struct
 {
-  rcl_init_options_t init_options;
   rcl_context_t context;
   rcl_allocator_t * allocator;
   rcl_clock_t clock;

--- a/rclc/src/rclc/init.c
+++ b/rclc/src/rclc/init.c
@@ -66,15 +66,8 @@ rclc_support_init_with_options(
     allocator, "allocator is a null pointer", return RCL_RET_INVALID_ARGUMENT);
   rcl_ret_t rc = RCL_RET_OK;
 
-  support->init_options = rcl_get_zero_initialized_init_options();
-  rc = rcl_init_options_copy(init_options, &support->init_options);
-  if (rc != RCL_RET_OK) {
-    PRINT_RCLC_ERROR(rclc_init, rcl_init_options_copy);
-    return rc;
-  }
-
   support->context = rcl_get_zero_initialized_context();
-  rc = rcl_init(argc, argv, &support->init_options, &support->context);
+  rc = rcl_init(argc, argv, init_options, &support->context);
   if (rc != RCL_RET_OK) {
     PRINT_RCLC_ERROR(rclc_init, rcl_init);
     return rc;
@@ -94,11 +87,6 @@ rclc_support_fini(rclc_support_t * support)
   RCL_CHECK_FOR_NULL_WITH_MSG(
     support, "support is a null pointer", return RCL_RET_INVALID_ARGUMENT);
   rcl_ret_t rc;
-  rc = rcl_init_options_fini(&support->init_options);
-  if (rc != RCL_RET_OK) {
-    PRINT_RCLC_WARN(rclc_support_fini, rcl_init_options_fini);
-    return rc;
-  }
   rc = rcl_clock_fini(&support->clock);
   if (rc != RCL_RET_OK) {
     PRINT_RCLC_WARN(rclc_support_fini, rcl_clock_fini);

--- a/rclc/src/rclc/init.c
+++ b/rclc/src/rclc/init.c
@@ -86,18 +86,22 @@ rclc_support_fini(rclc_support_t * support)
 {
   RCL_CHECK_FOR_NULL_WITH_MSG(
     support, "support is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+  rcl_ret_t result = RCL_RET_OK;
   rcl_ret_t rc;
   rc = rcl_clock_fini(&support->clock);
   if (rc != RCL_RET_OK) {
     PRINT_RCLC_WARN(rclc_support_fini, rcl_clock_fini);
+    result = RCL_RET_ERROR;
   }
   rc = rcl_shutdown(&support->context);
   if (rc != RCL_RET_OK) {
     PRINT_RCLC_WARN(rclc_support_fini, rcl_shutdown);
+    result = RCL_RET_ERROR;
   }
   rc = rcl_context_fini(&support->context);
   if (rc != RCL_RET_OK) {
     PRINT_RCLC_WARN(rclc_support_fini, rcl_context_fini);
+    result = RCL_RET_ERROR;
   }
-  return rc;
+  return result;
 }

--- a/rclc/test/rclc/test_init.cpp
+++ b/rclc/test/rclc/test_init.cpp
@@ -73,7 +73,7 @@ TEST(Test, rclc_support_fini) {
   rcl_allocator_t allocator = rcl_get_default_allocator();
   rc = rclc_support_init(&support, 0, nullptr, &allocator);
   EXPECT_EQ(RCL_RET_OK, rc);
-  rclc_support_fini(&support);
+  rc = rclc_support_fini(&support);
   EXPECT_EQ(RCL_RET_OK, rc);
   // test invalid arguments
   rc = rclc_support_fini(nullptr);
@@ -81,6 +81,6 @@ TEST(Test, rclc_support_fini) {
   rcutils_reset_error();
   // test calling twice
   rc = rclc_support_fini(&support);
-  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rc);
+  EXPECT_EQ(RCL_RET_ERROR, rc);
   rcutils_reset_error();
 }


### PR DESCRIPTION
The `support->init_options` is not used anywhere on the rclc, and this object is already inside `rcl_context_t context`:
https://github.com/micro-ROS/rcl/blob/galactic/rcl/src/rcl/context_impl.h#L34


Depends on:
 - [x] #202  (backport to `main`)