### PR TITLE
Fix data_available reset for timer

### DIFF
--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -804,8 +804,7 @@ _rclc_check_for_new_data(rclc_executor_handle_t * handle, rcl_wait_set_t * wait_
 
     case TIMER:
       // case TIMER_WITH_CONTEXT:
-      handle->data_available = (NULL != wait_set->timers[handle->index]);
-      if (handle->data_available) {
+      if (wait_set->timers[handle->index]) {
         bool timer_is_ready = false;
         rc = rcl_timer_is_ready(handle->timer, &timer_is_ready);
         if (rc != RCL_RET_OK) {
@@ -814,7 +813,9 @@ _rclc_check_for_new_data(rclc_executor_handle_t * handle, rcl_wait_set_t * wait_
         }
         // actually this is a unnecessary check: if wait_set.timers[i] is true, then also
         // rcl_timer_is_ready() should return true.
-        if (!timer_is_ready) {
+        if (timer_is_ready) {
+          handle->data_available = true;
+        } else {
           // this code should never be executed
           handle->data_available = false;
           PRINT_RCLC_ERROR(rclc_read_input_data, rcl_timer_should_be_ready);

--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -804,7 +804,8 @@ _rclc_check_for_new_data(rclc_executor_handle_t * handle, rcl_wait_set_t * wait_
 
     case TIMER:
       // case TIMER_WITH_CONTEXT:
-      if (wait_set->timers[handle->index]) {
+      handle->data_available = (NULL != wait_set->timers[handle->index]);
+      if (handle->data_available) {
         bool timer_is_ready = false;
         rc = rcl_timer_is_ready(handle->timer, &timer_is_ready);
         if (rc != RCL_RET_OK) {
@@ -813,9 +814,7 @@ _rclc_check_for_new_data(rclc_executor_handle_t * handle, rcl_wait_set_t * wait_
         }
         // actually this is a unnecessary check: if wait_set.timers[i] is true, then also
         // rcl_timer_is_ready() should return true.
-        if (timer_is_ready) {
-          handle->data_available = true;
-        } else {
+        if (!timer_is_ready) {
           // this code should never be executed
           handle->data_available = false;
           PRINT_RCLC_ERROR(rclc_read_input_data, rcl_timer_should_be_ready);

--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -805,22 +805,6 @@ _rclc_check_for_new_data(rclc_executor_handle_t * handle, rcl_wait_set_t * wait_
     case TIMER:
       // case TIMER_WITH_CONTEXT:
       handle->data_available = (NULL != wait_set->timers[handle->index]);
-      if (handle->data_available) {
-        bool timer_is_ready = false;
-        rc = rcl_timer_is_ready(handle->timer, &timer_is_ready);
-        if (rc != RCL_RET_OK) {
-          PRINT_RCLC_ERROR(rclc_read_input_data, rcl_timer_is_ready);
-          return rc;
-        }
-        // actually this is a unnecessary check: if wait_set.timers[i] is true, then also
-        // rcl_timer_is_ready() should return true.
-        if (!timer_is_ready) {
-          // this code should never be executed
-          handle->data_available = false;
-          PRINT_RCLC_ERROR(rclc_read_input_data, rcl_timer_should_be_ready);
-          return RCL_RET_ERROR;
-        }
-      }
       break;
 
     case SERVICE:

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -1001,7 +1001,8 @@ TEST_F(TestDefaultExecutor, executor_spin_timer) {
   rc = rclc_executor_init(&executor, &this->context, 10, this->allocator_ptr);
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
 
-  const unsigned int spin_timeout = 500;
+  // spin_timeout must be < timer1_timeout
+  const unsigned int spin_timeout = 50;
   const unsigned int spin_repeat = 10;
   const unsigned int expected_callbacks = (spin_timeout * spin_repeat) / timer1_timeout;
   _cbt_cnt = 0;

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -49,6 +49,8 @@
 static unsigned int _executor_results[TC_SPIN_SOME_MAX_MSGS];
 static unsigned int _executor_results_i;
 
+// callback for timer
+static unsigned int _cbt_cnt = 0;
 // callback for topic "chatter1"
 static unsigned int _cb1_cnt = 0;
 static unsigned int _cb1_int_value = 0;
@@ -395,6 +397,7 @@ void my_timer_callback(rcl_timer_t * timer, int64_t last_call_time)
   // Optionally reconfigure, cancel, or reset the timer...
   if (timer != NULL) {
     // printf("Timer: time since last call %d\n", static_cast<int>(last_call_time));
+    _cbt_cnt++;
   }
 }
 
@@ -986,6 +989,31 @@ TEST_F(TestDefaultExecutor, executor_add_timer) {
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
   exp_number_of_timers = 1;
   EXPECT_EQ(executor.info.number_of_timers, exp_number_of_timers) << "#timers should be 1";
+
+  // tear down
+  rc = rclc_executor_fini(&executor);
+  EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
+}
+
+TEST_F(TestDefaultExecutor, executor_spin_timer) {
+  rcl_ret_t rc;
+  rclc_executor_t executor;
+  rc = rclc_executor_init(&executor, &this->context, 10, this->allocator_ptr);
+  EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
+
+  const unsigned int spin_timeout = 500;
+  const unsigned int spin_repeat = 10;
+  const unsigned int expected_callbacks = (spin_timeout * spin_repeat) / timer1_timeout;
+  _cbt_cnt = 0;
+
+  rc = rclc_executor_add_timer(&executor, &this->timer1);
+  EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
+
+  for (size_t i = 0; i < spin_repeat; i++) {
+    rclc_executor_spin_some(&executor, RCL_MS_TO_NS(spin_timeout));
+  }
+
+  EXPECT_EQ(_cbt_cnt, expected_callbacks);
 
   // tear down
   rc = rclc_executor_fini(&executor);


### PR DESCRIPTION
The modifications on https://github.com/ros2/rclc/pull/213 lead to a bug on timer execution period:

Timers `handle->data_available` is never set to false, as `timer_is_ready` is always expected to be true as explained here:
https://github.com/ros2/rclc/blob/f74d13b786ed01f86682dabd2483e38f00fdf71b/rclc/src/rclc/executor.c#L815-L817

We detected this bug on our hardware on the loop testbench ([link](https://github.com/micro-ROS/micro_ros_renesas_testbench/runs/4247758112?check_suite_focus=true)), where the `PublisherRate` test uses a timer to publish periodically ([source file](https://github.com/micro-ROS/micro_ros_renesas_testbench/blob/galactic/test/micro_ros_renesas_testbench/client_tests/PublisherRate.c)). With the latest change the timer callback occurs on every `rclc_executor_spin_some` call.

This is not replicable on a regular `rclc_executor_spin`.