### PR TITLE
executor ignore canceled timers

### DIFF
--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -1433,6 +1433,10 @@ _rclc_execute(rclc_executor_handle_t * handle)
       case TIMER:
         // case TIMER_WITH_CONTEXT:
         rc = rcl_timer_call(handle->timer);
+        if (rc == RCL_RET_TIMER_CANCELED) {
+          break;
+        }
+
         if (rc != RCL_RET_OK) {
           PRINT_RCLC_ERROR(rclc_execute, rcl_timer_call);
           return rc;

--- a/rclc/src/rclc/executor.c
+++ b/rclc/src/rclc/executor.c
@@ -1433,7 +1433,10 @@ _rclc_execute(rclc_executor_handle_t * handle)
       case TIMER:
         // case TIMER_WITH_CONTEXT:
         rc = rcl_timer_call(handle->timer);
+
+        // cancled timer are not handled, return success
         if (rc == RCL_RET_TIMER_CANCELED) {
+          rc = RCL_RET_OK;
           break;
         }
 

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -1038,8 +1038,8 @@ TEST_F(TestDefaultExecutor, executor_spin_timer_cancelled) {
 
   for (size_t i = 0; i < spin_repeat; i++) {
     rclc_executor_spin_some(&executor, RCL_MS_TO_NS(spin_timeout));
-    if(i > spin_repeat / 2){
-      rcl_timer_cancel (&this->timer1);
+    if (i > spin_repeat / 2) {
+      rcl_timer_cancel(&this->timer1);
     }
   }
 

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -1039,7 +1039,8 @@ TEST_F(TestDefaultExecutor, executor_spin_timer_cancelled) {
   for (size_t i = 0; i < spin_repeat; i++) {
     rclc_executor_spin_some(&executor, RCL_MS_TO_NS(spin_timeout));
     if (i > spin_repeat / 2) {
-      rcl_timer_cancel(&this->timer1);
+      rc = rcl_timer_cancel(&this->timer1);
+      EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
     }
   }
 

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -1021,6 +1021,67 @@ TEST_F(TestDefaultExecutor, executor_spin_timer) {
   EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
 }
 
+TEST_F(TestDefaultExecutor, executor_spin_publisher_timer_cancelled) {
+  rcl_ret_t rc;
+  rclc_executor_t executor;
+  unsigned int expected_msg;
+
+  rc = rclc_executor_init(&executor, &this->context, 10, this->allocator_ptr);
+  EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
+
+  _executor_results_init();
+
+  rc = rclc_executor_add_subscription(
+    &executor, &this->sub1, &this->sub1_msg,
+    &CALLBACK_1, ON_NEW_DATA);
+
+  rc = rclc_executor_add_timer(&executor, &this->timer1);
+
+  for (unsigned int i = 0; i < TC_SPIN_SOME_PUBLISHED_MSGS; i++) {
+    rc = rcl_publish(&this->pub1, &this->pub1_msg, nullptr);
+    EXPECT_EQ(RCL_RET_OK, rc) << " pub1 not published";
+  }
+
+  // wait until messages are received
+  bool success = false;
+  unsigned int tries;
+  unsigned int max_tries = 100;
+  uint64_t timeout_ns = 100000000;  // 100ms
+
+  // process subscriptions. Assumption: messages for sub1 available
+  for (unsigned int i = 0; i < 100; i++) {
+    // Assumption: messages for all sub1, sub2 and sub3 are available
+    _wait_for_msg(
+      &this->sub1, &this->context, max_tries, timeout_ns, &tries,
+      &success);
+    ASSERT_TRUE(success);
+
+    if (i > 50) {
+      rc = rcl_timer_cancel(&this->timer1);
+    }
+
+    EXPECT_EQ(RCL_RET_OK, rc) << "failed to cancel timer";
+
+    rc = rclc_executor_spin_some(&executor, rclc_test_timeout_ns);
+    if ((rc == RCL_RET_OK) || (rc == RCL_RET_TIMEOUT)) {
+      // valid return values
+    } else {
+      // any other error
+      EXPECT_EQ(RCL_RET_OK, rc) << "spin_some error";
+    }
+    if (_cb1_cnt == TC_SPIN_SOME_PUBLISHED_MSGS) {
+      break;
+    }
+  }
+
+  expected_msg = TC_SPIN_SOME_PUBLISHED_MSGS;
+  EXPECT_EQ(_cb1_cnt, expected_msg) << "cb1 msg does not match";
+
+  rc = rclc_executor_fini(&executor);
+  EXPECT_EQ(RCL_RET_OK, rc) << rcl_get_error_string().str;
+  rcutils_reset_error();
+}
+
 TEST_F(TestDefaultExecutor, executor_spin_timer_cancelled) {
   rcl_ret_t rc;
   rclc_executor_t executor;

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -1048,6 +1048,7 @@ TEST_F(TestDefaultExecutor, executor_spin_publisher_timer_cancelled) {
   unsigned int max_tries = 100;
   uint64_t timeout_ns = 100000000;  // 100ms
 
+  rc = rcl_timer_cancel(&this->timer1);
   // process subscriptions. Assumption: messages for sub1 available
   for (unsigned int i = 0; i < 100; i++) {
     // Assumption: messages for all sub1, sub2 and sub3 are available
@@ -1056,9 +1057,6 @@ TEST_F(TestDefaultExecutor, executor_spin_publisher_timer_cancelled) {
       &success);
     ASSERT_TRUE(success);
 
-    if (i > 50) {
-      rc = rcl_timer_cancel(&this->timer1);
-    }
 
     EXPECT_EQ(RCL_RET_OK, rc) << "failed to cancel timer";
 


### PR DESCRIPTION
This is similar behavior observed in rclcpp, canceled timers shouldn't be handled

https://github.com/ros2/rclcpp/blob/e03e98220d7c4a79bfc934d43d762e017b493e9c/rclcpp/include/rclcpp/timer.hpp#L213