### PR TITLE
Create service context in main

### DIFF
--- a/rclc_examples/src/example_lifecycle_node.c
+++ b/rclc_examples/src/example_lifecycle_node.c
@@ -108,9 +108,11 @@ int main(int argc, const char * argv[])
 
   // Register lifecycle services
   printf("registering lifecycle services...\n");
-  RCCHECK(rclc_lifecycle_init_get_state_server(&lifecycle_node, &executor));
-  RCCHECK(rclc_lifecycle_init_get_available_states_server(&lifecycle_node, &executor));
-  RCCHECK(rclc_lifecycle_init_change_state_server(&lifecycle_node, &executor));
+  rclc_lifecycle_service_context_t context;
+  context.lifecycle_node = &lifecycle_node;
+  RCCHECK(rclc_lifecycle_init_get_state_server(&context, &executor));
+  RCCHECK(rclc_lifecycle_init_get_available_states_server(&context, &executor));
+  RCCHECK(rclc_lifecycle_init_change_state_server(&context, &executor));
 
   // Register lifecycle service callbacks
   printf("registering callbacks...\n");

--- a/rclc_lifecycle/include/rclc_lifecycle/rclc_lifecycle.h
+++ b/rclc_lifecycle/include/rclc_lifecycle/rclc_lifecycle.h
@@ -62,19 +62,19 @@ typedef struct rclc_lifecycle_service_context_t
 RCLC_LIFECYCLE_PUBLIC
 rcl_ret_t
 rclc_lifecycle_init_get_state_server(
-  rclc_lifecycle_node_t * lifecycle_node,
+  rclc_lifecycle_service_context_t * context,
   rclc_executor_t * executor);
 
 RCLC_LIFECYCLE_PUBLIC
 rcl_ret_t
 rclc_lifecycle_init_get_available_states_server(
-  rclc_lifecycle_node_t * lifecycle_node,
+  rclc_lifecycle_service_context_t * context,
   rclc_executor_t * executor);
 
 RCLC_LIFECYCLE_PUBLIC
 rcl_ret_t
 rclc_lifecycle_init_change_state_server(
-  rclc_lifecycle_node_t * lifecycle_node,
+  rclc_lifecycle_service_context_t * context,
   rclc_executor_t * executor);
 
 RCLC_LIFECYCLE_PUBLIC

--- a/rclc_lifecycle/src/rclc_lifecycle/rclc_lifecycle.c
+++ b/rclc_lifecycle/src/rclc_lifecycle/rclc_lifecycle.c
@@ -51,6 +51,7 @@ rclc_make_node_a_lifecycle_node(
     allocator, "allocator is a null pointer", return RCL_RET_INVALID_ARGUMENT);
 
   lifecycle_node->node = node;
+  lifecycle_node->publish_transitions = enable_communication_interface;
 
   rcl_lifecycle_state_machine_options_t state_machine_options =
     rcl_lifecycle_get_default_state_machine_options();
@@ -334,23 +335,21 @@ rclc_lifecycle_execute_callback(
 
 rcl_ret_t
 rclc_lifecycle_init_get_state_server(
-  rclc_lifecycle_node_t * lifecycle_node,
+  rclc_lifecycle_service_context_t * context,
   rclc_executor_t * executor)
 {
   RCL_CHECK_FOR_NULL_WITH_MSG(
-    lifecycle_node, "lifecycle_node is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+    context, "context is a null pointer", return RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_FOR_NULL_WITH_MSG(
     executor, "executor is a null pointer", return RCL_RET_INVALID_ARGUMENT);
-  rclc_lifecycle_service_context_t context;
-  context.lifecycle_node = lifecycle_node;
 
   rcl_ret_t rc = rclc_executor_add_service_with_context(
     executor,
-    &lifecycle_node->state_machine->com_interface.srv_get_state,
-    &lifecycle_node->gs_req,
-    &lifecycle_node->gs_res,
+    &context->lifecycle_node->state_machine->com_interface.srv_get_state,
+    &context->lifecycle_node->gs_req,
+    &context->lifecycle_node->gs_res,
     rclc_lifecycle_get_state_callback,
-    &context);
+    context);
   if (rc != RCL_RET_OK) {
     PRINT_RCLC_ERROR(main, rclc_executor_add_service_with_context);
     return RCL_RET_ERROR;
@@ -370,6 +369,8 @@ rclc_lifecycle_get_state_callback(
     (lifecycle_msgs__srv__GetState_Response *) res;
   rclc_lifecycle_service_context_t * context_in =
     (rclc_lifecycle_service_context_t *) context;
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    context, "context is a null pointer", return RCL_RET_INVALID_ARGUMENT);
 
   rcl_lifecycle_state_machine_t * sm =
     context_in->lifecycle_node->state_machine;
@@ -387,24 +388,19 @@ rclc_lifecycle_get_state_callback(
 
 rcl_ret_t
 rclc_lifecycle_init_get_available_states_server(
-  rclc_lifecycle_node_t * lifecycle_node,
+  rclc_lifecycle_service_context_t * context,
   rclc_executor_t * executor)
 {
   RCL_CHECK_FOR_NULL_WITH_MSG(
-    lifecycle_node, "lifecycle_node is a null pointer", return RCL_RET_INVALID_ARGUMENT);
-  RCL_CHECK_FOR_NULL_WITH_MSG(
     executor, "executor is a null pointer", return RCL_RET_INVALID_ARGUMENT);
-
-  rclc_lifecycle_service_context_t context;
-  context.lifecycle_node = lifecycle_node;
 
   rcl_ret_t rc = rclc_executor_add_service_with_context(
     executor,
-    &lifecycle_node->state_machine->com_interface.srv_get_available_states,
-    &lifecycle_node->gas_req,
-    &lifecycle_node->gas_res,
+    &context->lifecycle_node->state_machine->com_interface.srv_get_available_states,
+    &context->lifecycle_node->gas_req,
+    &context->lifecycle_node->gas_res,
     rclc_lifecycle_get_available_states_callback,
-    &context);
+    context);
   if (rc != RCL_RET_OK) {
     PRINT_RCLC_ERROR(main, rclc_executor_add_service_with_context);
     return RCL_RET_ERROR;
@@ -446,22 +442,16 @@ rclc_lifecycle_get_available_states_callback(
 
 rcl_ret_t
 rclc_lifecycle_init_change_state_server(
-  rclc_lifecycle_node_t * lifecycle_node,
+  rclc_lifecycle_service_context_t * context,
   rclc_executor_t * executor)
 {
-  RCL_CHECK_FOR_NULL_WITH_MSG(
-    lifecycle_node, "lifecycle_node is a null pointer", return RCL_RET_INVALID_ARGUMENT);
-
-  rclc_lifecycle_service_context_t context;
-  context.lifecycle_node = lifecycle_node;
-
   rcl_ret_t rc = rclc_executor_add_service_with_context(
     executor,
-    &lifecycle_node->state_machine->com_interface.srv_change_state,
-    &lifecycle_node->cs_req,
-    &lifecycle_node->cs_res,
+    &context->lifecycle_node->state_machine->com_interface.srv_change_state,
+    &context->lifecycle_node->cs_req,
+    &context->lifecycle_node->cs_res,
     rclc_lifecycle_change_state_callback,
-    &context);
+    context);
   if (rc != RCL_RET_OK) {
     PRINT_RCLC_ERROR(main, rclc_executor_add_service_with_context);
     return RCL_RET_ERROR;
@@ -482,6 +472,8 @@ rclc_lifecycle_change_state_callback(
     (lifecycle_msgs__srv__ChangeState_Response *) res;
   rclc_lifecycle_service_context_t * context_in =
     (rclc_lifecycle_service_context_t *) context;
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    context, "context is a null pointer", return RCL_RET_INVALID_ARGUMENT);
 
   rclc_lifecycle_node_t * ln = context_in->lifecycle_node;
   rcl_ret_t rc = rclc_lifecycle_change_state(ln, req_in->transition.id, true);

--- a/rclc_lifecycle/src/rclc_lifecycle/rclc_lifecycle.c
+++ b/rclc_lifecycle/src/rclc_lifecycle/rclc_lifecycle.c
@@ -369,8 +369,6 @@ rclc_lifecycle_get_state_callback(
     (lifecycle_msgs__srv__GetState_Response *) res;
   rclc_lifecycle_service_context_t * context_in =
     (rclc_lifecycle_service_context_t *) context;
-  RCL_CHECK_FOR_NULL_WITH_MSG(
-    context, "context is a null pointer", return RCL_RET_INVALID_ARGUMENT);
 
   rcl_lifecycle_state_machine_t * sm =
     context_in->lifecycle_node->state_machine;
@@ -472,8 +470,6 @@ rclc_lifecycle_change_state_callback(
     (lifecycle_msgs__srv__ChangeState_Response *) res;
   rclc_lifecycle_service_context_t * context_in =
     (rclc_lifecycle_service_context_t *) context;
-  RCL_CHECK_FOR_NULL_WITH_MSG(
-    context, "context is a null pointer", return RCL_RET_INVALID_ARGUMENT);
 
   rclc_lifecycle_node_t * ln = context_in->lifecycle_node;
   rcl_ret_t rc = rclc_lifecycle_change_state(ln, req_in->transition.id, true);

--- a/rclc_lifecycle/test/test_lifecycle.cpp
+++ b/rclc_lifecycle/test/test_lifecycle.cpp
@@ -252,6 +252,9 @@ TEST(TestRclcLifecycle, lifecycle_node_servers) {
   rclc_lifecycle_register_on_deactivate(&lifecycle_node, &callback_mockup_2);
   rclc_lifecycle_register_on_cleanup(&lifecycle_node, &callback_mockup_3);
 
+  rclc_lifecycle_service_context_t lcontext;
+  lcontext.lifecycle_node = &lifecycle_node;
+
   // create lifecycle servers
   rclc_executor_t executor;
   res = rclc_executor_init(
@@ -262,9 +265,9 @@ TEST(TestRclcLifecycle, lifecycle_node_servers) {
   EXPECT_EQ(RCL_RET_OK, res);
 
   // Too little executor handles
-  res = rclc_lifecycle_init_get_state_server(&lifecycle_node, &executor);
+  res = rclc_lifecycle_init_get_state_server(&lcontext, &executor);
   EXPECT_EQ(RCL_RET_OK, res);
-  res = rclc_lifecycle_init_get_available_states_server(&lifecycle_node, &executor);
+  res = rclc_lifecycle_init_get_available_states_server(&lcontext, &executor);
   EXPECT_EQ(RCL_RET_ERROR, res);
 
   // Now with correct number of handles
@@ -273,11 +276,11 @@ TEST(TestRclcLifecycle, lifecycle_node_servers) {
     &context,
     3,  // 1 for each lifecycle service
     &allocator);
-  res = rclc_lifecycle_init_get_state_server(&lifecycle_node, &executor);
+  res = rclc_lifecycle_init_get_state_server(&lcontext, &executor);
   EXPECT_EQ(RCL_RET_OK, res);
-  res = rclc_lifecycle_init_get_available_states_server(&lifecycle_node, &executor);
+  res = rclc_lifecycle_init_get_available_states_server(&lcontext, &executor);
   EXPECT_EQ(RCL_RET_OK, res);
-  res = rclc_lifecycle_init_change_state_server(&lifecycle_node, &executor);
+  res = rclc_lifecycle_init_change_state_server(&lcontext, &executor);
   EXPECT_EQ(RCL_RET_OK, res);
 
   // Cleanup


### PR DESCRIPTION
Context passed to the lifecycle services needs to be created in main.

Fixes https://github.com/ros2/rclc/issues/223

Signed-off-by: Nordmann Arne (CR/ADT3) <arne.nordmann@de.bosch.com>