### PR TITLE
Note wrt lifecycle services implemented for rolling

### DIFF
--- a/rclc_lifecycle/README.md
+++ b/rclc_lifecycle/README.md
@@ -86,4 +86,4 @@ An example, how to use the RCLC Lifecycle Node is given in the file `lifecycle_n
 
 ## Limitations
 
-The state machine publishes state changes, however, lifecycle services are not yet exposed via ROS 2 services (tbd).
+* The state machine publishes state changes, however, lifecycle services are not yet exposed via ROS 2 services. This has been added for rolling.


### PR DESCRIPTION
Note wrt. lifecycle services - missing in foxy - implemented for rolling.

@JanStaschulat Lifecycle services are not available in foxy anyway. So I just added a note that they are available in rolling.

Signed-off-by: Nordmann Arne (CR/ADT3) <arne.nordmann@de.bosch.com>