### PR TITLE
added dependency for package performance-test-fixture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         apt-get install ros-${{ matrix.ros_distribution }}-test-msgs
         apt-get install ros-${{ matrix.ros_distribution }}-rclcpp-action
         apt-get install ros-${{ matrix.ros_distribution }}-mimick-vendor
-        apt-get install ros-${{ matrix.ros_distribution }}-performance-test-fixture
+        apt-get -y install ros-${{ matrix.ros_distribution }}-performance-test-fixture
     - uses : ros-tooling/action-ros-ci@0.2.3
       with:
         package-name: "rclc rclc_examples rclc_lifecycle rclc_parameter"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,10 @@ jobs:
         required-ros-distributions: ${{ matrix.ros_distribution }}
     - name : Download and install rclc-dependencies
       run: |
-        apt-get install ros-${{ matrix.ros_distribution }}-osrf-testing-tools-cpp
-        apt-get install ros-${{ matrix.ros_distribution }}-test-msgs
-        apt-get install ros-${{ matrix.ros_distribution }}-rclcpp-action
-        apt-get install ros-${{ matrix.ros_distribution }}-performance-test-fixture
+        apt-get -y install ros-${{ matrix.ros_distribution }}-osrf-testing-tools-cpp
+        apt-get -y install ros-${{ matrix.ros_distribution }}-test-msgs
+        apt-get -y install ros-${{ matrix.ros_distribution }}-rclcpp-action
+        apt-get -y install ros-${{ matrix.ros_distribution }}-performance-test-fixture
     - uses : ros-tooling/action-ros-ci@0.2.1
       with:
         package-name: "rclc rclc_examples rclc_lifecycle rclc_parameter"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         apt-get -y install ros-${{ matrix.ros_distribution }}-osrf-testing-tools-cpp
         apt-get -y install ros-${{ matrix.ros_distribution }}-test-msgs
         apt-get -y install ros-${{ matrix.ros_distribution }}-rclcpp-action
-        apt-get -y install ros-${{ matrix.ros_distribution }}-mimick
+        apt-get -y install ros-${{ matrix.ros_distribution }}-mimick-vendor
         apt-get -y install ros-${{ matrix.ros_distribution }}-performance-test-fixture
     - uses : ros-tooling/action-ros-ci@0.2.1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
         apt-get -y install ros-${{ matrix.ros_distribution }}-osrf-testing-tools-cpp
         apt-get -y install ros-${{ matrix.ros_distribution }}-test-msgs
         apt-get -y install ros-${{ matrix.ros_distribution }}-rclcpp-action
+        apt-get -y install ros-${{ matrix.ros_distribution }}-mimick
         apt-get -y install ros-${{ matrix.ros_distribution }}-performance-test-fixture
     - uses : ros-tooling/action-ros-ci@0.2.1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,12 @@ jobs:
         required-ros-distributions: ${{ matrix.ros_distribution }}
     - name : Download and install rclc-dependencies
       run: |
-        apt-get -y install ros-${{ matrix.ros_distribution }}-osrf-testing-tools-cpp
-        apt-get -y install ros-${{ matrix.ros_distribution }}-test-msgs
-        apt-get -y install ros-${{ matrix.ros_distribution }}-rclcpp-action
-        apt-get -y install ros-${{ matrix.ros_distribution }}-mimick-vendor
-        apt-get -y install ros-${{ matrix.ros_distribution }}-performance-test-fixture
-    - uses : ros-tooling/action-ros-ci@0.2.1
+        apt-get install ros-${{ matrix.ros_distribution }}-osrf-testing-tools-cpp
+        apt-get install ros-${{ matrix.ros_distribution }}-test-msgs
+        apt-get install ros-${{ matrix.ros_distribution }}-rclcpp-action
+        apt-get install ros-${{ matrix.ros_distribution }}-mimick-vendor
+        apt-get install ros-${{ matrix.ros_distribution }}-performance-test-fixture
+    - uses : ros-tooling/action-ros-ci@0.2.3
       with:
         package-name: "rclc rclc_examples rclc_lifecycle rclc_parameter"
         vcs-repo-file-url: dependencies.repos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
         apt-get install ros-${{ matrix.ros_distribution }}-osrf-testing-tools-cpp
         apt-get install ros-${{ matrix.ros_distribution }}-test-msgs
         apt-get install ros-${{ matrix.ros_distribution }}-rclcpp-action
+        apt-get install ros-${{ matrix.ros_distribution }}-performance-test-fixture
     - uses : ros-tooling/action-ros-ci@0.2.1
       with:
         package-name: "rclc rclc_examples rclc_lifecycle rclc_parameter"


### PR DESCRIPTION
failing CI build in rclc on rolling: first failing build on https://github.com/ros2/rclc/runs/5136827515?check_suite_focus=true
resolves issue https://github.com/ros2/rclc/issues/246

CC: @norro 