### PR TITLE
Remove duplicate typedefs

### DIFF
--- a/rclc/include/rclc/executor_handle.h
+++ b/rclc/include/rclc/executor_handle.h
@@ -71,19 +71,6 @@ typedef rclc_subscription_callback_t rclc_callback_t;
 /// - additional callback context
 typedef void (* rclc_subscription_callback_with_context_t)(const void *, void *);
 
-/// Type definition for subscription callback function
-/// - incoming message
-typedef void (* rclc_subscription_callback_t)(const void *);
-
-/// Type definition (duplicate) for subscription callback function (alias for foxy and galactic).
-/// - incoming message
-typedef rclc_subscription_callback_t rclc_callback_t;
-
-/// Type definition for subscription callback function
-/// - incoming message
-/// - additional callback context
-typedef void (* rclc_subscription_callback_with_context_t)(const void *, void *);
-
 /// Type definition for client callback function
 /// - request message
 /// - response message


### PR DESCRIPTION
There are three typedefs that got duplicated in executor_handle.h. It looks like a copy/paste accident. 

I'm using a really old compiler, and it generates an error for the redefinition. I'm guessing it's not an error with modern compilers, but it's still nice to remove unnecessary stuff from the header.