### PR TITLE
Fix RCLC int parameter get

### DIFF
--- a/rclc_examples/src/example_parameter_server.c
+++ b/rclc_examples/src/example_parameter_server.c
@@ -30,10 +30,10 @@ void timer_callback(rcl_timer_t * timer, int64_t last_call_time)
   (void) timer;
   (void) last_call_time;
 
-  int value;
+  int64_t value;
   rclc_parameter_get_int(&param_server, "param2", &value);
   value++;
-  rclc_parameter_set_int(&param_server, "param2", (int64_t) value);
+  rclc_parameter_set_int(&param_server, "param2", value);
 }
 
 void on_parameter_changed(Parameter * param)
@@ -97,7 +97,7 @@ int main()
   rclc_parameter_set_double(&param_server, "param3", 0.01);
 
   bool param1;
-  int param2;
+  int64_t param2;
   double param3;
 
   rclc_parameter_get_bool(&param_server, "param1", &param1);

--- a/rclc_parameter/include/rclc_parameter/rclc_parameter.h
+++ b/rclc_parameter/include/rclc_parameter/rclc_parameter.h
@@ -340,7 +340,7 @@ rcl_ret_t
 rclc_parameter_get_int(
   rclc_parameter_server_t * parameter_server,
   const char * parameter_name,
-  int * output);
+  int64_t * output);
 
 /**
  *  Get the value of an existing a RCLC double parameter

--- a/rclc_parameter/src/rclc_parameter/parameter_server.c
+++ b/rclc_parameter/src/rclc_parameter/parameter_server.c
@@ -737,7 +737,7 @@ rcl_ret_t
 rclc_parameter_get_int(
   rclc_parameter_server_t * parameter_server,
   const char * parameter_name,
-  int * output)
+  int64_t * output)
 {
   RCL_CHECK_FOR_NULL_WITH_MSG(
     parameter_server, "parameter_server is a null pointer", return RCL_RET_INVALID_ARGUMENT);

--- a/rclc_parameter/test/rclc_parameter/test_parameter.cpp
+++ b/rclc_parameter/test/rclc_parameter/test_parameter.cpp
@@ -151,7 +151,7 @@ TEST(Test, rclc_node_init_default) {
 
   // Get parameters
   bool param1;
-  int param2;
+  int64_t param2;
   double param3;
 
   rclc_parameter_get_bool(&param_server, "param1", &param1);


### PR DESCRIPTION
Related: https://answers.ros.org/question/397640/why-ros2-rclc_parameter_set_int-has-value-parameter-as-int64_t-while-rclc_parameter_get_int-has-the-same-parameter-as-int-type/