### PR TITLE
Upgrade parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # The rclc repository
-This repository provides the rclc package, which complements the [ROS Client Support Library (rcl)](https://github.com/ros2/rcl/) to make up a complete ROS 2 client library for the C programming language. That is, rclc does not add a new layer of types on top of rcl (like rclcpp and rclpy do) but only provides convenience functions that ease the programming with the rcl types. New types are introduced only for concepts that are missing in rcl, most important an Executor and a Lifecycle Node.
+This repository provides the rclc package, which complements the [ROS Client Support Library (rcl)](https://github.com/ros2/rcl/) to make up a complete ROS 2 client library for the C programming language. That is, rclc does not add a new layer of types on top of rcl (like rclcpp and rclpy do) but only provides convenience functions that ease the programming with the rcl types. New types are introduced only for concepts that are missing in rcl, most important an Executor, Lifecycle Node and the Parameter server.
 
 In detail, this repository contains three packages:
 
 - [rclc](rclc/) provides the mentioned convenience functions for creating instances of publishers, subscriptions, nodes, etc. with the corresponding [rcl types](https://github.com/ros2/rcl/tree/master/rcl/include/rcl). Furthermore, it provides the rclc Executor for C, analogously to rclcpp's [Executor class](https://github.com/ros2/rclcpp/blob/master/rclcpp/include/rclcpp/executor.hpp) for C++. A key feature compared to the rclcpp Executor is that it includes features for implementing deterministic timing behavior.
 - [rclc_lifecycle](rclc_lifecycle/) introduces an rclc Lifecycle Node, bundling an rcl Node and the [lifecycle state machine](http://design.ros2.org/articles/node_lifecycle.html) from the [rcl_lifecycle package](https://github.com/ros2/rcl/tree/master/rcl_lifecycle).
 - [rclc_examples](rclc_examples/) provides small examples for the use of the convenience functions and the rclc Executor, as well as a small example for the use of the rclc Lifecycle Node.
+- [rclc_parameter](rclc_parameter/) provides convenience functions for creating parameter server instances with full ROS2 parameters client compatibility.
 
 Technical information on the interfaces and the usage of these packages is given in the README.md files in the corresponding subfolders.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # The rclc repository
 This repository provides the rclc package, which complements the [ROS Client Support Library (rcl)](https://github.com/ros2/rcl/) to make up a complete ROS 2 client library for the C programming language. That is, rclc does not add a new layer of types on top of rcl (like rclcpp and rclpy do) but only provides convenience functions that ease the programming with the rcl types. New types are introduced only for concepts that are missing in rcl, most important an Executor, Lifecycle Node and the Parameter server.
 
-In detail, this repository contains three packages:
+In detail, this repository contains four packages:
 
 - [rclc](rclc/) provides the mentioned convenience functions for creating instances of publishers, subscriptions, nodes, etc. with the corresponding [rcl types](https://github.com/ros2/rcl/tree/master/rcl/include/rcl). Furthermore, it provides the rclc Executor for C, analogously to rclcpp's [Executor class](https://github.com/ros2/rclcpp/blob/master/rclcpp/include/rclcpp/executor.hpp) for C++. A key feature compared to the rclcpp Executor is that it includes features for implementing deterministic timing behavior.
 - [rclc_lifecycle](rclc_lifecycle/) introduces an rclc Lifecycle Node, bundling an rcl Node and the [lifecycle state machine](http://design.ros2.org/articles/node_lifecycle.html) from the [rcl_lifecycle package](https://github.com/ros2/rcl/tree/master/rcl_lifecycle).

--- a/rclc_examples/src/example_parameter_server.c
+++ b/rclc_examples/src/example_parameter_server.c
@@ -36,23 +36,31 @@ void timer_callback(rcl_timer_t * timer, int64_t last_call_time)
   rclc_parameter_set_int(&param_server, "param2", value);
 }
 
-void on_parameter_changed(Parameter * param)
+bool on_parameter_changed(const Parameter * old_param, const Parameter * new_param)
 {
-  printf("Parameter %s modified.", param->name.data);
-  switch (param->value.type) {
-    case RCLC_PARAMETER_BOOL:
-      printf(" New value: %d (bool)", param->value.bool_value);
-      break;
-    case RCLC_PARAMETER_INT:
-      printf(" New value: %ld (int)", param->value.integer_value);
-      break;
-    case RCLC_PARAMETER_DOUBLE:
-      printf(" New value: %f (double)", param->value.double_value);
-      break;
-    default:
-      break;
+  if (old_param == NULL) {
+    printf("Creating new parameter %s\n", new_param->name.data);
+  } else if (new_param == NULL) {
+    printf("Deleting parameter %s\n", old_param->name.data);
+  } else {
+    printf("Parameter %s modified.", old_param->name.data);
+    switch (old_param->value.type) {
+      case RCLC_PARAMETER_BOOL:
+        printf(" Old value: %d, New value: %d (bool)", old_param->value.bool_value, new_param->value.bool_value);
+        break;
+      case RCLC_PARAMETER_INT:
+        printf(" Old value: %ld, New value: %ld (int)", old_param->value.integer_value, new_param->value.integer_value);
+        break;
+      case RCLC_PARAMETER_DOUBLE:
+        printf(" Old value: %f, New value: %f (double)", old_param->value.double_value, new_param->value.double_value);
+        break;
+      default:
+        break;
+    }
+    printf("\n");
   }
-  printf("\n");
+
+  return true;
 }
 
 int main()
@@ -95,6 +103,13 @@ int main()
   rclc_parameter_set_bool(&param_server, "param1", false);
   rclc_parameter_set_int(&param_server, "param2", 10);
   rclc_parameter_set_double(&param_server, "param3", 0.01);
+
+  // Add parameters constrains
+  rclc_add_parameter_description(&param_server, "param2", "Second parameter", false);
+  rclc_add_parameter_constraints_integer(&param_server, "param2", "Only even numbers", -10, 120, 2);
+
+  rclc_add_parameter_description(&param_server, "param3", "Third parameter", false);
+  rclc_add_parameter_constraints_double(&param_server, "param3", "", 0.0, 10.0, 0.1);
 
   bool param1;
   int64_t param2;

--- a/rclc_examples/src/example_parameter_server.c
+++ b/rclc_examples/src/example_parameter_server.c
@@ -114,7 +114,7 @@ int main()
 
   // Add parameters constraints
   rclc_add_parameter_description(&param_server, "param2", "Second parameter", "Only even numbers");
-  rclc_add_parameter_constraints_integer(&param_server, "param2", -10, 120, 2);
+  rclc_add_parameter_constraint_integer(&param_server, "param2", -10, 120, 2);
 
   rclc_add_parameter_description(&param_server, "param3", "Third parameter", "");
   rclc_set_parameter_read_only(&param_server, "param3", true);

--- a/rclc_examples/src/example_parameter_server.c
+++ b/rclc_examples/src/example_parameter_server.c
@@ -40,6 +40,11 @@ bool on_parameter_changed(const Parameter * old_param, const Parameter * new_par
 {
   (void) context;
 
+  if (old_param == NULL && new_param == NULL) {
+    printf("Callback error, both parameters are NULL\n");
+    return false;
+  }
+
   if (old_param == NULL) {
     printf("Creating new parameter %s\n", new_param->name.data);
   } else if (new_param == NULL) {
@@ -98,7 +103,7 @@ int main()
   // Create executor
   rclc_executor_t executor;
   rclc_executor_init(
-    &executor, &support.context, RCLC_PARAMETER_EXECUTOR_HANDLES_NUMBER + 1,
+    &executor, &support.context, RCLC_EXECUTOR_PARAMETER_SERVER_HANDLES + 1,
     &allocator);
   rclc_executor_add_parameter_server(&executor, &param_server, on_parameter_changed);
   rclc_executor_add_timer(&executor, &timer);

--- a/rclc_examples/src/example_parameter_server.c
+++ b/rclc_examples/src/example_parameter_server.c
@@ -105,11 +105,11 @@ int main()
   rclc_parameter_set_double(&param_server, "param3", 0.01);
 
   // Add parameters constrains
-  rclc_add_parameter_description(&param_server, "param2", "Second parameter", false);
-  rclc_add_parameter_constraints_integer(&param_server, "param2", "Only even numbers", -10, 120, 2);
+  rclc_add_parameter_description(&param_server, "param2", "Second parameter", "Only even numbers");
+  rclc_add_parameter_constraints_integer(&param_server, "param2",  -10, 120, 2);
 
-  rclc_add_parameter_description(&param_server, "param3", "Third parameter", false);
-  rclc_add_parameter_constraints_double(&param_server, "param3", "", 0.0, 10.0, 0.1);
+  rclc_add_parameter_description(&param_server, "param3", "Third parameter", "");
+  rclc_set_parameter_read_only(&param_server, "param3", true);
 
   bool param1;
   int64_t param2;

--- a/rclc_examples/src/example_parameter_server.c
+++ b/rclc_examples/src/example_parameter_server.c
@@ -112,7 +112,7 @@ int main()
   rclc_parameter_set_int(&param_server, "param2", 10);
   rclc_parameter_set_double(&param_server, "param3", 0.01);
 
-  // Add parameters constrains
+  // Add parameters constraints
   rclc_add_parameter_description(&param_server, "param2", "Second parameter", "Only even numbers");
   rclc_add_parameter_constraints_integer(&param_server, "param2", -10, 120, 2);
 

--- a/rclc_examples/src/example_parameter_server.c
+++ b/rclc_examples/src/example_parameter_server.c
@@ -36,8 +36,10 @@ void timer_callback(rcl_timer_t * timer, int64_t last_call_time)
   rclc_parameter_set_int(&param_server, "param2", value);
 }
 
-bool on_parameter_changed(const Parameter * old_param, const Parameter * new_param)
+bool on_parameter_changed(const Parameter * old_param, const Parameter * new_param, void * context)
 {
+  (void) context;
+
   if (old_param == NULL) {
     printf("Creating new parameter %s\n", new_param->name.data);
   } else if (new_param == NULL) {
@@ -46,13 +48,19 @@ bool on_parameter_changed(const Parameter * old_param, const Parameter * new_par
     printf("Parameter %s modified.", old_param->name.data);
     switch (old_param->value.type) {
       case RCLC_PARAMETER_BOOL:
-        printf(" Old value: %d, New value: %d (bool)", old_param->value.bool_value, new_param->value.bool_value);
+        printf(
+          " Old value: %d, New value: %d (bool)", old_param->value.bool_value,
+          new_param->value.bool_value);
         break;
       case RCLC_PARAMETER_INT:
-        printf(" Old value: %ld, New value: %ld (int)", old_param->value.integer_value, new_param->value.integer_value);
+        printf(
+          " Old value: %ld, New value: %ld (int)", old_param->value.integer_value,
+          new_param->value.integer_value);
         break;
       case RCLC_PARAMETER_DOUBLE:
-        printf(" Old value: %f, New value: %f (double)", old_param->value.double_value, new_param->value.double_value);
+        printf(
+          " Old value: %f, New value: %f (double)", old_param->value.double_value,
+          new_param->value.double_value);
         break;
       default:
         break;
@@ -106,7 +114,7 @@ int main()
 
   // Add parameters constrains
   rclc_add_parameter_description(&param_server, "param2", "Second parameter", "Only even numbers");
-  rclc_add_parameter_constraints_integer(&param_server, "param2",  -10, 120, 2);
+  rclc_add_parameter_constraints_integer(&param_server, "param2", -10, 120, 2);
 
   rclc_add_parameter_description(&param_server, "param3", "Third parameter", "");
   rclc_set_parameter_read_only(&param_server, "param3", true);

--- a/rclc_parameter/README.md
+++ b/rclc_parameter/README.md
@@ -114,44 +114,37 @@ Callback parameters:
 ```c
 bool on_parameter_changed(const Parameter * old_param, const Parameter * new_param, void * context)
 {
-    (void) context;
+  (void) context;
 
-    if (old_param == NULL)
-    {
-        printf("Creating new parameter %s\n", new_param->name.data);
+  if (old_param == NULL) {
+    printf("Creating new parameter %s\n", new_param->name.data);
+  } else if (new_param == NULL) {
+    printf("Deleting parameter %s\n", old_param->name.data);
+  } else {
+    printf("Parameter %s modified.", old_param->name.data);
+    switch (old_param->value.type) {
+      case RCLC_PARAMETER_BOOL:
+        printf(
+          " Old value: %d, New value: %d (bool)", old_param->value.bool_value,
+          new_param->value.bool_value);
+        break;
+      case RCLC_PARAMETER_INT:
+        printf(
+          " Old value: %ld, New value: %ld (int)", old_param->value.integer_value,
+          new_param->value.integer_value);
+        break;
+      case RCLC_PARAMETER_DOUBLE:
+        printf(
+          " Old value: %f, New value: %f (double)", old_param->value.double_value,
+          new_param->value.double_value);
+        break;
+      default:
+        break;
     }
-    else if (new_param == NULL)
-    {
-        printf("Deleting parameter %s\n", old_param->name.data);
-    }
-    else
-    {
-        printf("Parameter %s modified.", old_param->name.data);
-        switch (old_param->value.type)
-        {
-            case RCLC_PARAMETER_BOOL:
-                printf(
-                " Old value: %d, New value: %d (bool)", old_param->value.bool_value,
-                new_param->value.bool_value);
-                break;
-            case RCLC_PARAMETER_INT:
-                printf(
-                " Old value: %ld, New value: %ld (int)", old_param->value.integer_value,
-                new_param->value.integer_value);
-                break;
-            case RCLC_PARAMETER_DOUBLE:
-                printf(
-                " Old value: %f, New value: %f (double)", old_param->value.double_value,
-                new_param->value.double_value);
-                break;
-            default:
-                break;
-        }
+    printf("\n");
+  }
 
-        printf("\n");
-    }
-
-    return true;
+  return true;
 }
 ```
 
@@ -162,8 +155,8 @@ Parameters modifications are disabled while this callback is executed, causing t
 - rclc_parameter_set_int
 - rclc_parameter_set_double
 - rclc_set_parameter_read_only
-- rclc_add_parameter_constraints_double
-- rclc_add_parameter_constraints_integer
+- rclc_add_parameter_constraint_double
+- rclc_add_parameter_constraint_integer
 
 Once the parameter server and the executor are initialized, the parameter server must be added to the executor in order to accept parameters commands from ROS 2:
 ```c
@@ -262,20 +255,20 @@ Note that for external delete requests, the server callback will be executed, al
 
 - Parameter constraints  
     Informative numeric constraints can be added to int and double parameters, returning this values on describe parameters requests:
-    - from_value: Start value for valid values, inclusive.
-    - to_value: End value for valid values, inclusive.
-    - step: Size of valid steps between the from and to bound.
+    - `from_value`: Start value for valid values, inclusive.
+    - `to_value`: End value for valid values, inclusive.
+    - `step`: Size of valid steps between the from and to bound.
 
         ```c
         int64_t int_from = 0;
         int64_t int_to = 20;
         uint64_t int_step = 2;
-        rclc_add_parameter_constraints_integer(&param_server, "param2", int_from, int_to, int_step);
+        rclc_add_parameter_constraint_integer(&param_server, "param2", int_from, int_to, int_step);
 
         double double_from = -0.5;
         double double_to = 0.5;
         double double_step = 0.01;
-        rclc_add_parameter_constraints_double(&param_server, "param3", double_from, double_to, double_step);
+        rclc_add_parameter_constraint_double(&param_server, "param3", double_from, double_to, double_step);
         ```
 
     *This constrains will not be applied by the parameter server, leaving values filtering to the user callback.*

--- a/rclc_parameter/README.md
+++ b/rclc_parameter/README.md
@@ -2,19 +2,17 @@
 
 ROS 2 parameters allow the user to create variables on a node and manipulate/read them with different ROS2 commands. Further information about ROS 2 parameters can be found [here](https://docs.ros.org/en/galactic/Tutorials/Parameters/Understanding-ROS2-Parameters.html)
 
-This package provides the rclc with parameter server instances with full ROS2 parameters client compatibility. Rclc parameters clients are not implemented.
+This package provides the rclc with parameter server instances with full ROS2 parameters client compatibility, parameters clients are not implemented.  
 Ready to use code related to this tutorial can be found in [`rclc/rclc_examples/src/example_parameter_server.c`](../rclc_examples/src/example_parameter_server.c).
 
 ## Table of contents
-- [The rclc parameter package](#the-rclc-parameter-package)
-  - [Table of contents](#table-of-contents)
-  - [Initialization](#initialization)
-  - [Memory requirements](#memory-requirements)
-  - [Callback](#callback)
-  - [Add a parameter](#add-a-parameter)
-  - [Delete a parameter](#delete-a-parameter)
-  - [Parameters description](#parameters-description)
-  - [Cleaning up](#cleaning-up)
+*   [Initialization](#initialization)
+*   [Memory requirements](#memory-requirements)
+*   [Callback](#callback)
+*   [Add a parameter](#add-a-parameter)
+*   [Delete a parameter](#delete-a-parameter)
+*   [Parameters description](#parameters-description)
+*   [Cleaning up](#cleaning-up)
 
 ## Initialization
 
@@ -38,29 +36,30 @@ Ready to use code related to this tutorial can be found in [`rclc/rclc_examples/
   - notify_changed_over_dds: Publish parameters events to the rest of nodes.
   - max_params: Maximum number of parameters allowed on the `rclc_parameter_server_t` object.
   - allow_undeclared_parameters: Allows creation of parameters from external parameters clients. A new parameter will be created if a `set` operation is requested on a non-existing parameter.
-  - low_mem_mode: Reduces the memory used by the parameter server, functionality constrains are applied.
+  - low_mem_mode: Reduces the memory used by the parameter server, functionality constrains are applied.  
 
-  ```c
-  // Parameter server object
-  rclc_parameter_server_t param_server;
+    ```c
+    // Parameter server object
+    rclc_parameter_server_t param_server;
 
-  // Initialize parameter server options
-  const rclc_parameter_options_t options = {
-      .notify_changed_over_dds = true,
-      .max_params = 4,
-      .allow_undeclared_parameters = true,
-      .low_mem_mode = false; };
+    // Initialize parameter server options
+    const rclc_parameter_options_t options = {
+        .notify_changed_over_dds = true,
+        .max_params = 4,
+        .allow_undeclared_parameters = true,
+        .low_mem_mode = false; };
 
-  // Initialize parameter server with configured options
-  rcl_ret_t rc = rclc_parameter_server_init_with_option(&param_server, &node, &options);
+    // Initialize parameter server with configured options
+    rcl_ret_t rc = rclc_parameter_server_init_with_option(&param_server, &node, &options);
 
-  if (RCL_RET_OK != rc) {
-  ... // Handle error
-  return -1;
-  }
-  ```
+    if (RCL_RET_OK != rc) {
+    ... // Handle error
+    return -1;
+    }
+    ```
 
 - Low memory mode:
+
     This mode ports the parameters functionality to memory constrained devices. The following constrains are applied:
     - Request size limited to 1 parameter on Set, Get, Get types and Describe services.
     - List parameters request has no prefixes enabled nor depth.
@@ -74,7 +73,7 @@ Ready to use code related to this tutorial can be found in [`rclc/rclc_examples/
 
 The parameter server uses 5 services and an optional publisher, this needs to be taken into account on the `rmw-microxredds` package memory configuration:
 
-```json
+```yaml
 # colcon.meta example with memory requirements to use a parameter server
 {
     "names": {
@@ -117,37 +116,44 @@ Callback parameters:
 ```c
 bool on_parameter_changed(const Parameter * old_param, const Parameter * new_param, void * context)
 {
-(void) context;
+    (void) context;
 
-if (old_param == NULL) {
-    printf("Creating new parameter %s\n", new_param->name.data);
-} else if (new_param == NULL) {
-    printf("Deleting parameter %s\n", old_param->name.data);
-} else {
-    printf("Parameter %s modified.", old_param->name.data);
-    switch (old_param->value.type) {
-    case RCLC_PARAMETER_BOOL:
-        printf(
-        " Old value: %d, New value: %d (bool)", old_param->value.bool_value,
-        new_param->value.bool_value);
-        break;
-    case RCLC_PARAMETER_INT:
-        printf(
-        " Old value: %ld, New value: %ld (int)", old_param->value.integer_value,
-        new_param->value.integer_value);
-        break;
-    case RCLC_PARAMETER_DOUBLE:
-        printf(
-        " Old value: %f, New value: %f (double)", old_param->value.double_value,
-        new_param->value.double_value);
-        break;
-    default:
-        break;
+    if (old_param == NULL)
+    {
+        printf("Creating new parameter %s\n", new_param->name.data);
     }
-    printf("\n");
-}
+    else if (new_param == NULL)
+    {
+        printf("Deleting parameter %s\n", old_param->name.data);
+    }
+    else
+    {
+        printf("Parameter %s modified.", old_param->name.data);
+        switch (old_param->value.type)
+        {
+            case RCLC_PARAMETER_BOOL:
+                printf(
+                " Old value: %d, New value: %d (bool)", old_param->value.bool_value,
+                new_param->value.bool_value);
+                break;
+            case RCLC_PARAMETER_INT:
+                printf(
+                " Old value: %ld, New value: %ld (int)", old_param->value.integer_value,
+                new_param->value.integer_value);
+                break;
+            case RCLC_PARAMETER_DOUBLE:
+                printf(
+                " Old value: %f, New value: %f (double)", old_param->value.double_value,
+                new_param->value.double_value);
+                break;
+            default:
+                break;
+        }
 
-return true;
+        printf("\n");
+    }
+
+    return true;
 }
 ```
 
@@ -160,7 +166,6 @@ Parameters modifications are disabled while this callback is executed, causing t
 - rclc_set_parameter_read_only
 - rclc_add_parameter_constraints_double
 - rclc_add_parameter_constraints_integer
-
 
 Once the parameter server and the executor are initialized, the parameter server must be added to the executor in order to accept parameters commands from ROS2:
 ```c
@@ -199,8 +204,8 @@ micro-ROS parameter server supports the following parameter types:
     rc = rclc_parameter_get_bool(&param_server, "param1", &param_value);
 
     if (RCL_RET_OK != rc) {
-    ... // Handle error
-    return -1;
+        ... // Handle error
+        return -1;
     }
     ```
 
@@ -241,7 +246,6 @@ They client just needs to set a value on a unexisting parameter, the parameter w
 
 ## Delete a parameter
 Parameters can be deleted both by the parameter server and external clients:
-Example usage:
 ```c
 rclc_delete_parameter(&param_server, "param2");
 ```
@@ -250,39 +254,36 @@ Note that for external delete requests the server callback will be executed, all
 
 ## Parameters description
 
-- Parameter description
-    Adds a description of a parameter and its constrains. This descriptors will be returned to describe parameters requests.
-    Example usage:
+- Parameter description  
+    Adds a description of a parameter and its constrains, which will be returned on a describe parameters requests:
     ```c
     rclc_add_parameter_description(&param_server, "param2", "Second parameter", "Only even numbers");
     ```
 
     *The maximum string size is controlled by the compilation time option `RCLC_PARAMETER_MAX_STRING_LENGTH`, default value is 50.*
 
-- Parameter constrains
-    Informative numeric constrains can be added to int and double parameters, returning this values on describe parameters requests.
-    Note that this constrains will not be applied by the parameter server, leaving values filtering to the user callback.
-
-    The following values can be configured:
+- Parameter constrains  
+    Informative numeric constrains can be added to int and double parameters, returning this values on describe parameters requests:
     - from_value: Start value for valid values, inclusive.
     - to_value: End value for valid values, inclusive.
     - step: Size of valid steps between the from and to bound.
 
-    Example usage:
-    ```c
-    int64_t int_from = 0;
-    int64_t int_to = 20;
-    uint64_t int_step = 2;
-    rclc_add_parameter_constraints_integer(&param_server, "param2", int_from, int_to, int_step);
+        ```c
+        int64_t int_from = 0;
+        int64_t int_to = 20;
+        uint64_t int_step = 2;
+        rclc_add_parameter_constraints_integer(&param_server, "param2", int_from, int_to, int_step);
 
-    double double_from = -0.5;
-    double double_to = 0.5;
-    double double_step = 0.01;
-    rclc_add_parameter_constraints_double(&param_server, "param3", double_from, double_to, double_step);
-    ```
+        double double_from = -0.5;
+        double double_to = 0.5;
+        double double_step = 0.01;
+        rclc_add_parameter_constraints_double(&param_server, "param3", double_from, double_to, double_step);
+        ```
 
-- Read only parameters:
-    The new API offers a read only flag. This flag blocks parameter changes from external clients, but allows changes on the server side. Example usage:
+    *This constrains will not be applied by the parameter server, leaving values filtering to the user callback.*
+
+- Read only parameters:  
+    The new API offers a read only flag. This flag blocks parameter changes from external clients, but allows changes on the server side:
     ```c
     bool read_only = true;
     rclc_set_parameter_read_only(&param_server, "param3", read_only);

--- a/rclc_parameter/README.md
+++ b/rclc_parameter/README.md
@@ -1,6 +1,6 @@
 # The rclc parameter package
 
-ROS 2 parameters allow the user to create variables on a node and manipulate/read them with different ROS 2 commands. Further information about ROS 2 parameters can be found [here](https://docs.ros.org/en/galactic/Tutorials/Parameters/Understanding-ROS2-Parameters.html)
+ROS 2 parameters allow the user to create variables on a node and manipulate/read them with different ROS 2 commands. Further information about ROS 2 parameters can be found [here](https://docs.ros.org/en/rolling/Tutorials/Parameters/Understanding-ROS2-Parameters.html)
 
 This package provides the rclc with parameter server instances with full ROS 2 parameters client compatibility. A parameters client for rclc has not been implemented (yet).
 Ready to use code related to this tutorial can be found in [`rclc/rclc_examples/src/example_parameter_server.c`](../rclc_examples/src/example_parameter_server.c).
@@ -231,7 +231,7 @@ micro-ROS parameter server supports the following parameter types:
     ```
 
 Parameters can also be created by external clients if `allow_undeclared_parameters` flag is set.
-They client just needs to set a value on a unexisting parameter, the parameter will be created if the server is not full and the callback allows the operation.
+The client just needs to set a value on a unexisting parameter, the parameter will be created if the server is not full and the callback allows the operation.
 
 *Max name size is controlled by the compile-time option `RCLC_PARAMETER_MAX_STRING_LENGTH`, default value is 50.*
 
@@ -289,4 +289,4 @@ To destroy an initialized parameter server:
 rclc_parameter_server_fini(&param_server, &node);
 ```
 
-This will delete any automatically created infrastructure on the agent (if possible) and deallocate used memory on the client side.
+This will delete any automatically created infrastructure on the agent (if possible) and deallocate used memory on the parameter server side.

--- a/rclc_parameter/README.md
+++ b/rclc_parameter/README.md
@@ -1,8 +1,8 @@
 # The rclc parameter package
 
-ROS 2 parameters allow the user to create variables on a node and manipulate/read them with different ROS2 commands. Further information about ROS 2 parameters can be found [here](https://docs.ros.org/en/galactic/Tutorials/Parameters/Understanding-ROS2-Parameters.html)
+ROS 2 parameters allow the user to create variables on a node and manipulate/read them with different ROS 2 commands. Further information about ROS 2 parameters can be found [here](https://docs.ros.org/en/galactic/Tutorials/Parameters/Understanding-ROS2-Parameters.html)
 
-This package provides the rclc with parameter server instances with full ROS2 parameters client compatibility, parameters clients are not implemented.  
+This package provides the rclc with parameter server instances with full ROS 2 parameters client compatibility. A parameters client for rclc has not been implemented (yet).
 Ready to use code related to this tutorial can be found in [`rclc/rclc_examples/src/example_parameter_server.c`](../rclc_examples/src/example_parameter_server.c).
 
 ## Table of contents
@@ -20,13 +20,12 @@ Ready to use code related to this tutorial can be found in [`rclc/rclc_examples/
     ```c
     // Parameter server object
     rclc_parameter_server_t param_server;
-
     // Initialize parameter server with default configuration
     rcl_ret_t rc = rclc_parameter_server_init_default(&param_server, &node);
 
     if (RCL_RET_OK != rc) {
-    ... // Handle error
-    return -1;
+      ... // Handle error
+      return -1;
     }
     ```
 
@@ -51,10 +50,9 @@ Ready to use code related to this tutorial can be found in [`rclc/rclc_examples/
 
     // Initialize parameter server with configured options
     rcl_ret_t rc = rclc_parameter_server_init_with_option(&param_server, &node, &options);
-
     if (RCL_RET_OK != rc) {
-    ... // Handle error
-    return -1;
+      ... // Handle error
+      return -1;
     }
     ```
 
@@ -71,7 +69,7 @@ Ready to use code related to this tutorial can be found in [`rclc/rclc_examples/
 
 ## Memory requirements
 
-The parameter server uses 5 services and an optional publisher, this needs to be taken into account on the `rmw-microxredds` package memory configuration:
+The parameter server uses five services and an optional publisher. These need to be taken into account on the `rmw-microxredds` package memory configuration:
 
 ```yaml
 # colcon.meta example with memory requirements to use a parameter server
@@ -90,7 +88,7 @@ The parameter server uses 5 services and an optional publisher, this needs to be
 }
 ```
 
-On runtime, the variable `RCLC_PARAMETER_EXECUTOR_HANDLES_NUMBER` defines the RCLC executor handles required for a parameter server:
+At runtime, the variable `RCLC_PARAMETER_EXECUTOR_HANDLES_NUMBER` defines the rclc Executor handles required for a parameter server:
 
 ```c
 // Executor init example with the minimum RCLC executor handles required
@@ -109,9 +107,9 @@ When adding the parameter server to the executor, a callback can be configured. 
 - The user can allow or reject this operations using the `bool` return value.
 
 Callback parameters:
-- old_param: Parameter actual value, `NULL` for new parameter request.
-- new_param: Parameter new value, `NULL` for parameter removal request.
-- context: User context, configured on `rclc_executor_add_parameter_server_with_context`.
+- `old_param`: Parameter actual value, `NULL` for new parameter request.
+- `new_param`: Parameter new value, `NULL` for parameter removal request.
+- `context`: User context, configured on `rclc_executor_add_parameter_server_with_context`.
 
 ```c
 bool on_parameter_changed(const Parameter * old_param, const Parameter * new_param, void * context)
@@ -157,7 +155,7 @@ bool on_parameter_changed(const Parameter * old_param, const Parameter * new_par
 }
 ```
 
-Parameters modifications are disabled while this callback is executed, causing this methods to return `RCLC_PARAMETER_DISABLED_ON_CALLBACK`:
+Parameters modifications are disabled while this callback is executed, causing the following methods to return `RCLC_PARAMETER_DISABLED_ON_CALLBACK` if they are invoked:
 - rclc_add_parameter
 - rclc_delete_parameter
 - rclc_parameter_set_bool
@@ -167,7 +165,7 @@ Parameters modifications are disabled while this callback is executed, causing t
 - rclc_add_parameter_constraints_double
 - rclc_add_parameter_constraints_integer
 
-Once the parameter server and the executor are initialized, the parameter server must be added to the executor in order to accept parameters commands from ROS2:
+Once the parameter server and the executor are initialized, the parameter server must be added to the executor in order to accept parameters commands from ROS 2:
 ```c
 // Add parameter server to executor including defined callback
 rc = rclc_executor_add_parameter_server(&executor, &param_server, on_parameter_changed);
@@ -242,15 +240,15 @@ micro-ROS parameter server supports the following parameter types:
 Parameters can also be created by external clients if `allow_undeclared_parameters` flag is set.
 They client just needs to set a value on a unexisting parameter, the parameter will be created if the server is not full and the callback allows the operation.
 
-*Max name size is controlled by the compilation time option `RCLC_PARAMETER_MAX_STRING_LENGTH`, default value is 50.*
+*Max name size is controlled by the compile-time option `RCLC_PARAMETER_MAX_STRING_LENGTH`, default value is 50.*
 
 ## Delete a parameter
-Parameters can be deleted both by the parameter server and external clients:
+Parameters can be deleted by both, the parameter server and external clients:
 ```c
 rclc_delete_parameter(&param_server, "param2");
 ```
 
-Note that for external delete requests the server callback will be executed, allowing the user to reject the operation.
+Note that for external delete requests, the server callback will be executed, allowing the node to reject the operation.
 
 ## Parameters description
 
@@ -262,8 +260,8 @@ Note that for external delete requests the server callback will be executed, all
 
     *The maximum string size is controlled by the compilation time option `RCLC_PARAMETER_MAX_STRING_LENGTH`, default value is 50.*
 
-- Parameter constrains  
-    Informative numeric constrains can be added to int and double parameters, returning this values on describe parameters requests:
+- Parameter constraints  
+    Informative numeric constraints can be added to int and double parameters, returning this values on describe parameters requests:
     - from_value: Start value for valid values, inclusive.
     - to_value: End value for valid values, inclusive.
     - step: Size of valid steps between the from and to bound.
@@ -282,8 +280,8 @@ Note that for external delete requests the server callback will be executed, all
 
     *This constrains will not be applied by the parameter server, leaving values filtering to the user callback.*
 
-- Read only parameters:  
-    The new API offers a read only flag. This flag blocks parameter changes from external clients, but allows changes on the server side:
+- Read-only parameters:  
+    The new API offers a read-only flag. This flag blocks parameter changes from external clients, but allows changes on the server side:
     ```c
     bool read_only = true;
     rclc_set_parameter_read_only(&param_server, "param3", read_only);

--- a/rclc_parameter/README.md
+++ b/rclc_parameter/README.md
@@ -1,0 +1,300 @@
+# The rclc parameter package
+
+ROS 2 parameters allow the user to create variables on a node and manipulate/read them with different ROS2 commands. Further information about ROS 2 parameters can be found [here](https://docs.ros.org/en/galactic/Tutorials/Parameters/Understanding-ROS2-Parameters.html)
+
+This package provides the rclc with parameter server instances with full ROS2 parameters client compatibility. Rclc parameters clients are not implemented.
+Ready to use code related to this tutorial can be found in [`rclc/rclc_examples/src/example_parameter_server.c`](../rclc_examples/src/example_parameter_server.c).
+
+## Table of contents
+- [The rclc parameter package](#the-rclc-parameter-package)
+  - [Table of contents](#table-of-contents)
+  - [Initialization](#initialization)
+  - [Memory requirements](#memory-requirements)
+  - [Callback](#callback)
+  - [Add a parameter](#add-a-parameter)
+  - [Delete a parameter](#delete-a-parameter)
+  - [Parameters description](#parameters-description)
+  - [Cleaning up](#cleaning-up)
+
+## Initialization
+
+- Default initialization:
+    ```c
+    // Parameter server object
+    rclc_parameter_server_t param_server;
+
+    // Initialize parameter server with default configuration
+    rcl_ret_t rc = rclc_parameter_server_init_default(&param_server, &node);
+
+    if (RCL_RET_OK != rc) {
+    ... // Handle error
+    return -1;
+    }
+    ```
+
+- Custom options:
+
+  The following options can be configured:
+  - notify_changed_over_dds: Publish parameters events to the rest of nodes.
+  - max_params: Maximum number of parameters allowed on the `rclc_parameter_server_t` object.
+  - allow_undeclared_parameters: Allows creation of parameters from external parameters clients. A new parameter will be created if a `set` operation is requested on a non-existing parameter.
+  - low_mem_mode: Reduces the memory used by the parameter server, functionality constrains are applied.
+
+  ```c
+  // Parameter server object
+  rclc_parameter_server_t param_server;
+
+  // Initialize parameter server options
+  const rclc_parameter_options_t options = {
+      .notify_changed_over_dds = true,
+      .max_params = 4,
+      .allow_undeclared_parameters = true,
+      .low_mem_mode = false; };
+
+  // Initialize parameter server with configured options
+  rcl_ret_t rc = rclc_parameter_server_init_with_option(&param_server, &node, &options);
+
+  if (RCL_RET_OK != rc) {
+  ... // Handle error
+  return -1;
+  }
+  ```
+
+- Low memory mode:
+    This mode ports the parameters functionality to memory constrained devices. The following constrains are applied:
+    - Request size limited to 1 parameter on Set, Get, Get types and Describe services.
+    - List parameters request has no prefixes enabled nor depth.
+    - Parameter description strings not allowed, `rclc_add_parameter_description` is disabled.
+
+    Memory benchmark on `STM32F4` for 7 parameters with `RCLC_PARAMETER_MAX_STRING_LENGTH = 50` and `notify_changed_over_dds = true`:
+    - Full mode: 11736 B
+    - Low memory mode: 4160 B
+
+## Memory requirements
+
+The parameter server uses 5 services and an optional publisher, this needs to be taken into account on the `rmw-microxredds` package memory configuration:
+
+```json
+# colcon.meta example with memory requirements to use a parameter server
+{
+    "names": {
+        "rmw_microxrcedds": {
+            "cmake-args": [
+                "-DRMW_UXRCE_MAX_NODES=1",
+                "-DRMW_UXRCE_MAX_PUBLISHERS=1",
+                "-DRMW_UXRCE_MAX_SUBSCRIPTIONS=0",
+                "-DRMW_UXRCE_MAX_SERVICES=5",
+                "-DRMW_UXRCE_MAX_CLIENTS=0"
+            ]
+        }
+    }
+}
+```
+
+On runtime, the variable `RCLC_PARAMETER_EXECUTOR_HANDLES_NUMBER` defines the RCLC executor handles required for a parameter server:
+
+```c
+// Executor init example with the minimum RCLC executor handles required
+rclc_executor_t executor = rclc_executor_get_zero_initialized_executor();
+rc = rclc_executor_init(
+    &executor, &support.context,
+    RCLC_PARAMETER_EXECUTOR_HANDLES_NUMBER, &allocator);
+```
+
+## Callback
+
+When adding the parameter server to the executor, a callback can be configured. This callback will be executed on the following events:  
+- Parameter value change: Internal and external parameter set on existing parameters.
+- Parameter creation: External parameter set on unexisting parameter if `allow_undeclared_parameters` is set.
+- Parameter delete: External parameter delete on existing parameter.
+- The user can allow or reject this operations using the `bool` return value.
+
+Callback parameters:
+- old_param: Parameter actual value, `NULL` for new parameter request.
+- new_param: Parameter new value, `NULL` for parameter removal request.
+- context: User context, configured on `rclc_executor_add_parameter_server_with_context`.
+
+```c
+bool on_parameter_changed(const Parameter * old_param, const Parameter * new_param, void * context)
+{
+(void) context;
+
+if (old_param == NULL) {
+    printf("Creating new parameter %s\n", new_param->name.data);
+} else if (new_param == NULL) {
+    printf("Deleting parameter %s\n", old_param->name.data);
+} else {
+    printf("Parameter %s modified.", old_param->name.data);
+    switch (old_param->value.type) {
+    case RCLC_PARAMETER_BOOL:
+        printf(
+        " Old value: %d, New value: %d (bool)", old_param->value.bool_value,
+        new_param->value.bool_value);
+        break;
+    case RCLC_PARAMETER_INT:
+        printf(
+        " Old value: %ld, New value: %ld (int)", old_param->value.integer_value,
+        new_param->value.integer_value);
+        break;
+    case RCLC_PARAMETER_DOUBLE:
+        printf(
+        " Old value: %f, New value: %f (double)", old_param->value.double_value,
+        new_param->value.double_value);
+        break;
+    default:
+        break;
+    }
+    printf("\n");
+}
+
+return true;
+}
+```
+
+Parameters modifications are disabled while this callback is executed, causing this methods to return `RCLC_PARAMETER_DISABLED_ON_CALLBACK`:
+- rclc_add_parameter
+- rclc_delete_parameter
+- rclc_parameter_set_bool
+- rclc_parameter_set_int
+- rclc_parameter_set_double
+- rclc_set_parameter_read_only
+- rclc_add_parameter_constraints_double
+- rclc_add_parameter_constraints_integer
+
+
+Once the parameter server and the executor are initialized, the parameter server must be added to the executor in order to accept parameters commands from ROS2:
+```c
+// Add parameter server to executor including defined callback
+rc = rclc_executor_add_parameter_server(&executor, &param_server, on_parameter_changed);
+```
+
+Note that this callback is optional as its just an event information for the user. To use the parameter server without a callback:
+```c
+// Add parameter server to executor without callback
+rc = rclc_executor_add_parameter_server(&executor, &param_server, NULL);
+```
+
+To configure the callback context:
+```c
+// Add parameter server to executor including defined callback and a context
+rc = rclc_executor_add_parameter_server_with_context(&executor, &param_server, on_parameter_changed, &context);
+```
+
+## Add a parameter
+
+micro-ROS parameter server supports the following parameter types:
+
+- Boolean:
+    ```c
+    const char * parameter_name = "parameter_bool";
+    bool param_value = true;
+
+    // Add parameter to the server
+    rcl_ret_t rc = rclc_add_parameter(&param_server, parameter_name, RCLC_PARAMETER_BOOL);
+
+    // Set parameter value (Triggers parameter change callback)
+    rc = rclc_parameter_set_bool(&param_server, parameter_name, param_value);
+
+    // Get parameter value on param_value
+    rc = rclc_parameter_get_bool(&param_server, "param1", &param_value);
+
+    if (RCL_RET_OK != rc) {
+    ... // Handle error
+    return -1;
+    }
+    ```
+
+- Integer:
+    ```c
+    const char * parameter_name = "parameter_int";
+    int param_value = 100;
+
+    // Add parameter to the server
+    rcl_ret_t rc = rclc_add_parameter(&param_server, parameter_name, RCLC_PARAMETER_INT);
+
+    // Set parameter value
+    rc = rclc_parameter_set_int(&param_server, parameter_name, param_value);
+
+    // Get parameter value on param_value
+    rc = rclc_parameter_get_int(&param_server, parameter_name, &param_value);
+    ```
+
+- Double:
+    ```c
+    const char * parameter_name = "parameter_double";
+    double param_value = 0.15;
+
+    // Add parameter to the server
+    rcl_ret_t rc = rclc_add_parameter(&param_server, parameter_name, RCLC_PARAMETER_DOUBLE);
+
+    // Set parameter value
+    rc = rclc_parameter_set_double(&param_server, parameter_name, param_value);
+
+    // Get parameter value on param_value
+    rc = rclc_parameter_get_double(&param_server, parameter_name, &param_value);
+    ```
+
+Parameters can also be created by external clients if `allow_undeclared_parameters` flag is set.
+They client just needs to set a value on a unexisting parameter, the parameter will be created if the server is not full and the callback allows the operation.
+
+*Max name size is controlled by the compilation time option `RCLC_PARAMETER_MAX_STRING_LENGTH`, default value is 50.*
+
+## Delete a parameter
+Parameters can be deleted both by the parameter server and external clients:
+Example usage:
+```c
+rclc_delete_parameter(&param_server, "param2");
+```
+
+Note that for external delete requests the server callback will be executed, allowing the user to reject the operation.
+
+## Parameters description
+
+- Parameter description
+    Adds a description of a parameter and its constrains. This descriptors will be returned to describe parameters requests.
+    Example usage:
+    ```c
+    rclc_add_parameter_description(&param_server, "param2", "Second parameter", "Only even numbers");
+    ```
+
+    *The maximum string size is controlled by the compilation time option `RCLC_PARAMETER_MAX_STRING_LENGTH`, default value is 50.*
+
+- Parameter constrains
+    Informative numeric constrains can be added to int and double parameters, returning this values on describe parameters requests.
+    Note that this constrains will not be applied by the parameter server, leaving values filtering to the user callback.
+
+    The following values can be configured:
+    - from_value: Start value for valid values, inclusive.
+    - to_value: End value for valid values, inclusive.
+    - step: Size of valid steps between the from and to bound.
+
+    Example usage:
+    ```c
+    int64_t int_from = 0;
+    int64_t int_to = 20;
+    uint64_t int_step = 2;
+    rclc_add_parameter_constraints_integer(&param_server, "param2", int_from, int_to, int_step);
+
+    double double_from = -0.5;
+    double double_to = 0.5;
+    double double_step = 0.01;
+    rclc_add_parameter_constraints_double(&param_server, "param3", double_from, double_to, double_step);
+    ```
+
+- Read only parameters:
+    The new API offers a read only flag. This flag blocks parameter changes from external clients, but allows changes on the server side. Example usage:
+    ```c
+    bool read_only = true;
+    rclc_set_parameter_read_only(&param_server, "param3", read_only);
+    ```
+
+## Cleaning up
+
+To destroy an initialized parameter server:
+
+```c
+// Delete parameter server
+rclc_parameter_server_fini(&param_server, &node);
+```
+
+This will delete any automatically created infrastructure on the agent (if possible) and deallocate used memory on the client side.

--- a/rclc_parameter/include/rclc_parameter/rclc_parameter.h
+++ b/rclc_parameter/include/rclc_parameter/rclc_parameter.h
@@ -67,7 +67,7 @@ typedef struct rcl_interfaces__msg__ParameterDescriptor__Sequence ParameterDescr
 typedef struct rcl_interfaces__msg__ParameterEvent ParameterEvent;
 
 // Number of RCLC executor handles required for a parameter server
-#define RCLC_PARAMETER_EXECUTOR_HANDLES_NUMBER 5
+#define RCLC_EXECUTOR_PARAMETER_SERVER_HANDLES 5
 #define RCLC_PARAMETER_MODIFICATION_REJECTED 4001
 #define RCLC_PARAMETER_TYPE_MISMATCH 4002
 #define RCLC_PARAMETER_UNSUPORTED_ON_LOW_MEM 4003

--- a/rclc_parameter/include/rclc_parameter/rclc_parameter.h
+++ b/rclc_parameter/include/rclc_parameter/rclc_parameter.h
@@ -454,7 +454,7 @@ rclc_parameter_get_double(
 
 
 /**
- * Add a description to a parameter (Unsuported on low memory mode).
+ * Add a description to a parameter. (This feature is disabled in low memory mode.)
  * This description will be returned on describe parameters requests.
  *
  * <hr>
@@ -504,8 +504,8 @@ rclc_set_parameter_read_only(
   const char * parameter_name, bool read_only);
 
 /**
- * Add constraint description for an integer parameter.
- * This constraint description will be returned on describe parameters requests.
+ * Sets a constraint on an integer parameter.
+ * This constraint specification will be returned on describe parameters requests.
  * This method is disabled on user callback execution.
  *
  * <hr>
@@ -530,8 +530,8 @@ rclc_add_parameter_constraints_integer(
   const char * parameter_name, int64_t from_value, int64_t to_value, uint64_t step);
 
 /**
- * Add constraint description for an double parameter.
- * This constraint description will be returned on describe parameters requests.
+ * Sets a constraint on an double parameter.
+ * This constraint specification will be returned on describe parameters requests.
  * This method is disabled on user callback execution.
  *
  * <hr>

--- a/rclc_parameter/include/rclc_parameter/rclc_parameter.h
+++ b/rclc_parameter/include/rclc_parameter/rclc_parameter.h
@@ -90,8 +90,8 @@ typedef struct rcl_interfaces__msg__ParameterEvent ParameterEvent;
  * Uses Atomics       | No
  * Lock-Free          | No
  *
- * \param[in] param Parameter actual value, `NULL` for new parameter request.
- * \param[in] new_value Parameter new value, `NULL` for parameter removal request.
+ * \param[in] old_param Parameter actual value, `NULL` for new parameter request.
+ * \param[in] new_param Parameter new value, `NULL` for parameter removal request.
  * \param[in] context Context of the callback.
  * \return `true` to accept the parameter event. The operation will be rejected on `false` return.
  */
@@ -501,7 +501,8 @@ RCLC_PARAMETER_PUBLIC
 rcl_ret_t
 rclc_set_parameter_read_only(
   rclc_parameter_server_t * parameter_server,
-  const char * parameter_name, bool read_only);
+  const char * parameter_name,
+  bool read_only);
 
 /**
  * Sets a constraint on an integer parameter.
@@ -527,7 +528,10 @@ RCLC_PARAMETER_PUBLIC
 rcl_ret_t
 rclc_add_parameter_constraint_integer(
   rclc_parameter_server_t * parameter_server,
-  const char * parameter_name, int64_t from_value, int64_t to_value, uint64_t step);
+  const char * parameter_name,
+  int64_t from_value,
+  int64_t to_value,
+  uint64_t step);
 
 /**
  * Sets a constraint on an double parameter.
@@ -553,7 +557,10 @@ RCLC_PARAMETER_PUBLIC
 rcl_ret_t
 rclc_add_parameter_constraint_double(
   rclc_parameter_server_t * parameter_server,
-  const char * parameter_name, double from_value, double to_value, double step);
+  const char * parameter_name,
+  double from_value,
+  double to_value,
+  double step);
 
 #if __cplusplus
 }

--- a/rclc_parameter/include/rclc_parameter/rclc_parameter.h
+++ b/rclc_parameter/include/rclc_parameter/rclc_parameter.h
@@ -93,7 +93,7 @@ typedef struct rcl_interfaces__msg__ParameterEvent ParameterEvent;
  * \param[in] old_param Parameter actual value, `NULL` for new parameter request.
  * \param[in] new_param Parameter new value, `NULL` for parameter removal request.
  * \param[in] context Context of the callback.
- * \return `true` to accept the parameter event. The operation will be rejected on `false` return.
+ * \return `true` to accept the parameter event. If the operation was rejected, `false` is returned.
  */
 typedef bool (* rclc_parameter_callback_t)(
   const Parameter * old_param,
@@ -476,7 +476,8 @@ RCLC_PARAMETER_PUBLIC
 rcl_ret_t
 rclc_add_parameter_description(
   rclc_parameter_server_t * parameter_server,
-  const char * parameter_name, const char * parameter_description,
+  const char * parameter_name,
+  const char * parameter_description,
   const char * additional_constraints);
 
 /**

--- a/rclc_parameter/include/rclc_parameter/rclc_parameter.h
+++ b/rclc_parameter/include/rclc_parameter/rclc_parameter.h
@@ -71,13 +71,16 @@ typedef struct rcl_interfaces__msg__ParameterEvent ParameterEvent;
 #define PARAMETER_MODIFICATION_REJECTED 4001
 #define PARAMETER_TYPE_MISMATCH 4002
 #define UNSUPORTED_ON_LOW_MEM 4003
+#define DISABLE_ON_CALLBACK 40004
 
 /**
- *  Parameter event callback
+ *  Parameter event callback.
  *  This callback will allow the user to allow or reject the following events:
  *  - Parameter value change: Internal and external parameter set on existing parameters.
  *  - Parameter creation: External parameter set on unexisting parameter if `allow_undeclared_parameters` is set.
  *  - Parameter delete: External parameter delete on existing parameter.
+ *
+ *  Parameters modifications are disabled while this callback is executed.
  *
  * <hr>
  * Attribute          | Adherence
@@ -91,7 +94,9 @@ typedef struct rcl_interfaces__msg__ParameterEvent ParameterEvent;
  * \param[in] new_value Parameter new value, `NULL` for parameter removal request.
  * \return `true` to accept the parameter event. The operation will be rejected on `false` return.
  */
-typedef bool (* ModifiedParameter_Callback)(const Parameter * param, const Parameter * new_value);
+typedef bool (* ModifiedParameter_Callback)(
+  const Parameter * old_param,
+  const Parameter * new_param);
 
 // Allowed RCLC parameter types
 typedef enum rclc_parameter_type_t
@@ -142,6 +147,7 @@ typedef struct rclc_parameter_server_t
   ParameterEvent event_list;
 
   ModifiedParameter_Callback on_modification;
+  bool on_callback;
 
   bool notify_changed_over_dds;
   bool allow_undeclared_parameters;
@@ -230,10 +236,11 @@ RCLC_PARAMETER_PUBLIC
 rcl_ret_t rclc_executor_add_parameter_server(
   rclc_executor_t * executor,
   rclc_parameter_server_t * parameter_server,
-  ModifiedParameter_Callback ModifiedParameter_Callback);
+  ModifiedParameter_Callback on_modification);
 
 /**
  *  Adds a RCLC parameter to a server
+ *  This method is disabled on user callback execution.
  *
  * <hr>
  * Attribute          | Adherence
@@ -256,7 +263,8 @@ rclc_add_parameter(
   rclc_parameter_type_t type);
 
 /**
- *  Deletes a RCLC parameter from the server
+ *  Deletes a RCLC parameter from the server.
+ *  This method is disabled on user callback execution.
  *
  * <hr>
  * Attribute          | Adherence
@@ -277,7 +285,8 @@ rclc_delete_parameter(
   const char * parameter_name);
 
 /**
- *  Sets the value of an existing a RCLC bool parameter
+ *  Sets the value of an existing a RCLC bool parameter.
+ *  This method is disabled on user callback execution.
  *
  * <hr>
  * Attribute          | Adherence
@@ -300,7 +309,8 @@ rclc_parameter_set_bool(
   bool value);
 
 /**
- *  Sets the value of an existing a RCLC integer parameter
+ *  Sets the value of an existing a RCLC integer parameter.
+ *  This method is disabled on user callback execution.
  *
  * <hr>
  * Attribute          | Adherence
@@ -323,7 +333,8 @@ rclc_parameter_set_int(
   int64_t value);
 
 /**
- *  Sets the value of an existing a RCLC double parameter
+ *  Sets the value of an existing a RCLC double parameter.
+ *  This method is disabled on user callback execution.
  *
  * <hr>
  * Attribute          | Adherence
@@ -444,6 +455,7 @@ rclc_add_parameter_description(
 /**
  * Sets a parameter read only flag.
  * Read only parameters can only be modified from the `rclc_parameter_set` API.
+ * This method is disabled on user callback execution.
  *
  * <hr>
  * Attribute          | Adherence
@@ -467,6 +479,7 @@ rclc_set_parameter_read_only(
 /**
  * Add constraint description for an integer parameter.
  * This constraint description will be returned on describe parameters requests.
+ * This method is disabled on user callback execution.
  *
  * <hr>
  * Attribute          | Adherence
@@ -492,6 +505,7 @@ rclc_add_parameter_constraints_integer(
 /**
  * Add constraint description for an double parameter.
  * This constraint description will be returned on describe parameters requests.
+ * This method is disabled on user callback execution.
  *
  * <hr>
  * Attribute          | Adherence

--- a/rclc_parameter/include/rclc_parameter/rclc_parameter.h
+++ b/rclc_parameter/include/rclc_parameter/rclc_parameter.h
@@ -525,7 +525,7 @@ rclc_set_parameter_read_only(
  */
 RCLC_PARAMETER_PUBLIC
 rcl_ret_t
-rclc_add_parameter_constraints_integer(
+rclc_add_parameter_constraint_integer(
   rclc_parameter_server_t * parameter_server,
   const char * parameter_name, int64_t from_value, int64_t to_value, uint64_t step);
 
@@ -551,7 +551,7 @@ rclc_add_parameter_constraints_integer(
  */
 RCLC_PARAMETER_PUBLIC
 rcl_ret_t
-rclc_add_parameter_constraints_double(
+rclc_add_parameter_constraint_double(
   rclc_parameter_server_t * parameter_server,
   const char * parameter_name, double from_value, double to_value, double step);
 

--- a/rclc_parameter/src/rclc_parameter/parameter_server.c
+++ b/rclc_parameter/src/rclc_parameter/parameter_server.c
@@ -816,6 +816,9 @@ rclc_parameter_server_fini_memory_low_memory(
   parameter_server->get_request.names.size = 0;
 
   // Get response
+  allocator.deallocate(
+    parameter_server->get_response.values.data[0].string_value.data,
+    allocator.state);
   allocator.deallocate(parameter_server->get_response.values.data, allocator.state);
   parameter_server->get_response.values.capacity = 0;
   parameter_server->get_response.values.size = 0;
@@ -877,6 +880,14 @@ rclc_parameter_server_fini_memory_low_memory(
   // Parameter list and parameter descriptors
   for (size_t i = 0; i < parameter_server->parameter_list.capacity; i++) {
     allocator.deallocate(parameter_server->parameter_list.data[i].name.data, allocator.state);
+    allocator.deallocate(
+      parameter_server->parameter_list.data[i].value.string_value.data,
+      allocator.state);
+    allocator.deallocate(
+      parameter_server->parameter_descriptors.data[i].description.data,
+      allocator.state);
+    allocator.deallocate(
+      parameter_server->parameter_descriptors.data[i].additional_constraints.data, allocator.state);
     allocator.deallocate(
       parameter_server->parameter_descriptors.data[i].floating_point_range.data,
       allocator.state);

--- a/rclc_parameter/src/rclc_parameter/parameter_server.c
+++ b/rclc_parameter/src/rclc_parameter/parameter_server.c
@@ -54,11 +54,11 @@ rclc_parameter_server_describe_service_callback(
   void * parameter_server)
 {
   RCL_CHECK_FOR_NULL_WITH_MSG(
-    req, "req is a null pointer", return);
+    req, "req is a null pointer", return );
   RCL_CHECK_FOR_NULL_WITH_MSG(
-    res, "res is a null pointer", return);
+    res, "res is a null pointer", return );
   RCL_CHECK_FOR_NULL_WITH_MSG(
-    parameter_server, "parameter_server is a null pointer", return);
+    parameter_server, "parameter_server is a null pointer", return );
 
   rclc_parameter_server_t * param_server = (rclc_parameter_server_t *) parameter_server;
   DescribeParameters_Request * request = (DescribeParameters_Request *) req;
@@ -111,9 +111,9 @@ rclc_parameter_server_list_service_callback(
   void * parameter_server)
 {
   RCL_CHECK_FOR_NULL_WITH_MSG(
-    res, "res is a null pointer", return);
+    res, "res is a null pointer", return );
   RCL_CHECK_FOR_NULL_WITH_MSG(
-    parameter_server, "parameter_server is a null pointer", return);
+    parameter_server, "parameter_server is a null pointer", return );
 
   (void) req;
 
@@ -140,11 +140,11 @@ rclc_parameter_server_get_service_callback(
   void * parameter_server)
 {
   RCL_CHECK_FOR_NULL_WITH_MSG(
-    req, "req is a null pointer", return);
+    req, "req is a null pointer", return );
   RCL_CHECK_FOR_NULL_WITH_MSG(
-    res, "res is a null pointer", return);
+    res, "res is a null pointer", return );
   RCL_CHECK_FOR_NULL_WITH_MSG(
-    parameter_server, "parameter_server is a null pointer", return);
+    parameter_server, "parameter_server is a null pointer", return );
 
   const GetParameters_Request * request = (const GetParameters_Request *) req;
   GetParameters_Response * response = (GetParameters_Response *) res;
@@ -181,11 +181,11 @@ rclc_parameter_server_get_types_service_callback(
   void * parameter_server)
 {
   RCL_CHECK_FOR_NULL_WITH_MSG(
-    req, "req is a null pointer", return);
+    req, "req is a null pointer", return );
   RCL_CHECK_FOR_NULL_WITH_MSG(
-    res, "res is a null pointer", return);
+    res, "res is a null pointer", return );
   RCL_CHECK_FOR_NULL_WITH_MSG(
-    parameter_server, "parameter_server is a null pointer", return);
+    parameter_server, "parameter_server is a null pointer", return );
 
   const GetParameterTypes_Request * request = (const GetParameterTypes_Request *)  req;
   GetParameterTypes_Response * response = (GetParameterTypes_Response *) res;
@@ -218,11 +218,11 @@ rclc_parameter_server_set_service_callback(
   void * parameter_server)
 {
   RCL_CHECK_FOR_NULL_WITH_MSG(
-    req, "req is a null pointer", return);
+    req, "req is a null pointer", return );
   RCL_CHECK_FOR_NULL_WITH_MSG(
-    res, "res is a null pointer", return);
+    res, "res is a null pointer", return );
   RCL_CHECK_FOR_NULL_WITH_MSG(
-    parameter_server, "parameter_server is a null pointer", return);
+    parameter_server, "parameter_server is a null pointer", return );
 
   const SetParameters_Request * request = (const SetParameters_Request *) req;
   SetParameters_Response * response = (SetParameters_Response *) res;
@@ -362,9 +362,6 @@ init_parameter_server_memory(
 
   rcl_ret_t ret = RCL_RET_OK;
 
-  static char empty_string[RCLC_PARAMETER_MAX_STRING_LENGTH] = "";
-  size_t empty_string_capacity = RCLC_PARAMETER_MAX_STRING_LENGTH - 1;
-
   bool mem_allocs_ok = true;
   mem_allocs_ok &= rcl_interfaces__msg__Parameter__Sequence__init(
     &parameter_server->parameter_list,
@@ -373,11 +370,8 @@ init_parameter_server_memory(
 
   // Pre-init strings
   for (size_t i = 0; i < options->max_params; ++i) {
-    mem_allocs_ok &= rosidl_runtime_c__String__assignn(
-      &parameter_server->parameter_list.data[i].name,
-      (const char *) empty_string,
-      empty_string_capacity);
-    parameter_server->parameter_list.data[i].name.size = 0;
+    mem_allocs_ok &= rclc_parameter_descriptor_initialize_string(
+      &parameter_server->parameter_list.data[i].name);
   }
 
   // Init list service msgs
@@ -392,11 +386,8 @@ init_parameter_server_memory(
 
   // Pre-init strings
   for (size_t i = 0; i < options->max_params; ++i) {
-    mem_allocs_ok &= rosidl_runtime_c__String__assignn(
-      &parameter_server->list_response.result.names.data[i],
-      (const char *) empty_string,
-      empty_string_capacity);
-    parameter_server->list_response.result.names.data[i].size = 0;
+    mem_allocs_ok &= rclc_parameter_descriptor_initialize_string(
+      &parameter_server->list_response.result.names.data[i]);
   }
 
   // Init Get service msgs
@@ -414,11 +405,8 @@ init_parameter_server_memory(
 
   // Pre-init strings
   for (size_t i = 0; i < options->max_params; ++i) {
-    mem_allocs_ok &= rosidl_runtime_c__String__assignn(
-      &parameter_server->get_request.names.data[i],
-      (const char *) empty_string,
-      empty_string_capacity);
-    parameter_server->get_request.names.data[i].size = 0;
+    mem_allocs_ok &= rclc_parameter_descriptor_initialize_string(
+      &parameter_server->get_request.names.data[i]);
   }
 
   // Init Set service msgs
@@ -434,22 +422,12 @@ init_parameter_server_memory(
     options->max_params);
   parameter_server->set_response.results.size = 0;
 
-  static char empty_string_reason[RCLC_SET_ERROR_MAX_STRING_LENGTH] = "";
-  size_t string_reason_capacity = RCLC_SET_ERROR_MAX_STRING_LENGTH - 1;
-
   // Pre-init strings
   for (size_t i = 0; i < options->max_params; ++i) {
-    mem_allocs_ok &= rosidl_runtime_c__String__assignn(
-      &parameter_server->set_request.parameters.data[i].name,
-      (const char *) empty_string,
-      empty_string_capacity);
-    parameter_server->set_request.parameters.data[i].name.size = 0;
-
-    mem_allocs_ok &= rosidl_runtime_c__String__assignn(
-      &parameter_server->set_response.results.data[i].reason,
-      (const char *) empty_string_reason,
-      string_reason_capacity);
-    parameter_server->set_response.results.data[i].reason.size = 0;
+    mem_allocs_ok &= rclc_parameter_descriptor_initialize_string(
+      &parameter_server->set_request.parameters.data[i].name);
+    mem_allocs_ok &= rclc_parameter_descriptor_initialize_string(
+      &parameter_server->set_response.results.data[i].reason);
   }
 
   // Init Get types service msgs
@@ -467,11 +445,8 @@ init_parameter_server_memory(
   parameter_server->get_types_response.types.size = 0;
 
   for (size_t i = 0; i < options->max_params; ++i) {
-    mem_allocs_ok &= rosidl_runtime_c__String__assignn(
-      &parameter_server->get_types_request.names.data[i],
-      (const char *) empty_string,
-      empty_string_capacity);
-    parameter_server->get_types_request.names.data[i].size = 0;
+    mem_allocs_ok &= rclc_parameter_descriptor_initialize_string(
+      &parameter_server->get_types_request.names.data[i]);
   }
 
   // Init Describe service msgs
@@ -496,28 +471,16 @@ init_parameter_server_memory(
 
   for (size_t i = 0; i < options->max_params; ++i) {
     // Init describe_request members
-    mem_allocs_ok &= rosidl_runtime_c__String__assignn(
-      &parameter_server->describe_request.names.data[i],
-      (const char *) empty_string,
-      empty_string_capacity);
-    parameter_server->describe_request.names.data[i].size = 0;
+    mem_allocs_ok &= rclc_parameter_descriptor_initialize_string(
+      &parameter_server->describe_request.names.data[i]);
 
     // Init describe_response members
-    mem_allocs_ok &= rosidl_runtime_c__String__assignn(
-      &parameter_server->describe_response.descriptors.data[i].name,
-      (const char *) empty_string,
-      empty_string_capacity);
-    parameter_server->describe_response.descriptors.data[i].name.size = 0;
-    mem_allocs_ok &= rosidl_runtime_c__String__assignn(
-      &parameter_server->describe_response.descriptors.data[i].description,
-      (const char *) empty_string,
-      empty_string_capacity);
-    parameter_server->describe_response.descriptors.data[i].description.size = 0;
-    mem_allocs_ok &= rosidl_runtime_c__String__assignn(
-      &parameter_server->describe_response.descriptors.data[i].additional_constraints,
-      (const char *) empty_string,
-      empty_string_capacity);
-    parameter_server->describe_response.descriptors.data[i].additional_constraints.size = 0;
+    mem_allocs_ok &= rclc_parameter_descriptor_initialize_string(
+      &parameter_server->describe_response.descriptors.data[i].name);
+    mem_allocs_ok &= rclc_parameter_descriptor_initialize_string(
+      &parameter_server->describe_response.descriptors.data[i].description);
+    mem_allocs_ok &= rclc_parameter_descriptor_initialize_string(
+      &parameter_server->describe_response.descriptors.data[i].additional_constraints);
     mem_allocs_ok &= rcl_interfaces__msg__FloatingPointRange__Sequence__init(
       &parameter_server->describe_response.descriptors.data[i].floating_point_range,
       rcl_interfaces__msg__ParameterDescriptor__floating_point_range__MAX_SIZE);
@@ -528,21 +491,12 @@ init_parameter_server_memory(
     parameter_server->describe_response.descriptors.data[i].integer_range.size = 0;
 
     // Init parameter_descriptors members
-    mem_allocs_ok &= rosidl_runtime_c__String__assignn(
-      &parameter_server->parameter_descriptors.data[i].name,
-      (const char *) empty_string,
-      empty_string_capacity);
-    parameter_server->parameter_descriptors.data[i].name.size = 0;
-    mem_allocs_ok &= rosidl_runtime_c__String__assignn(
-      &parameter_server->parameter_descriptors.data[i].description,
-      (const char *) empty_string,
-      empty_string_capacity);
-    parameter_server->parameter_descriptors.data[i].description.size = 0;
-    mem_allocs_ok &= rosidl_runtime_c__String__assignn(
-      &parameter_server->parameter_descriptors.data[i].additional_constraints,
-      (const char *) empty_string,
-      empty_string_capacity);
-    parameter_server->parameter_descriptors.data[i].additional_constraints.size = 0;
+    mem_allocs_ok &= rclc_parameter_descriptor_initialize_string(
+      &parameter_server->parameter_descriptors.data[i].name);
+    mem_allocs_ok &= rclc_parameter_descriptor_initialize_string(
+      &parameter_server->parameter_descriptors.data[i].description);
+    mem_allocs_ok &= rclc_parameter_descriptor_initialize_string(
+      &parameter_server->parameter_descriptors.data[i].additional_constraints);
     mem_allocs_ok &= rcl_interfaces__msg__FloatingPointRange__Sequence__init(
       &parameter_server->parameter_descriptors.data[i].floating_point_range,
       rcl_interfaces__msg__ParameterDescriptor__floating_point_range__MAX_SIZE);
@@ -599,29 +553,17 @@ rcl_ret_t init_parameter_server_memory_low(
   parameter_server->parameter_descriptors.capacity = options->max_params;
 
   for (size_t i = 0; i < options->max_params; ++i) {
-    parameter_server->parameter_list.data[i].name.data = allocator.allocate(
-      sizeof(char) * RCLC_PARAMETER_MAX_STRING_LENGTH, allocator.state);
-    parameter_server->parameter_list.data[i].name.data[0] = '\0';
-    parameter_server->parameter_list.data[i].name.capacity = RCLC_PARAMETER_MAX_STRING_LENGTH;
-    parameter_server->parameter_list.data[i].name.size = 0;
-
-    parameter_server->parameter_list.data[i].value.string_value.data =
-      allocator.allocate(sizeof(char), allocator.state);
-    parameter_server->parameter_list.data[i].value.string_value.data[0] = '\0';
-    parameter_server->parameter_list.data[i].value.string_value.capacity = 1;
-    parameter_server->parameter_list.data[i].value.string_value.size = 0;
-
-    parameter_server->parameter_descriptors.data[i].description.data =
-      allocator.allocate(sizeof(char), allocator.state);
-    parameter_server->parameter_descriptors.data[i].description.data[0] = '\0';
-    parameter_server->parameter_descriptors.data[i].description.capacity = 1;
-    parameter_server->parameter_descriptors.data[i].description.size = 0;
-
-    parameter_server->parameter_descriptors.data[i].additional_constraints.data =
-      allocator.allocate(sizeof(char), allocator.state);
-    parameter_server->parameter_descriptors.data[i].additional_constraints.data[0] = '\0';
-    parameter_server->parameter_descriptors.data[i].additional_constraints.capacity = 1;
-    parameter_server->parameter_descriptors.data[i].additional_constraints.size = 0;
+    ret |= rclc_parameter_initialize_empty_string(
+      &parameter_server->parameter_list.data[i].name,
+      RCLC_PARAMETER_MAX_STRING_LENGTH);
+    ret |=
+      rclc_parameter_initialize_empty_string(
+      &parameter_server->parameter_list.data[i].value.string_value, 1);
+    ret |=
+      rclc_parameter_initialize_empty_string(
+      &parameter_server->parameter_descriptors.data[i].description, 1);
+    ret |= rclc_parameter_initialize_empty_string(
+      &parameter_server->parameter_descriptors.data[i].additional_constraints, 1);
 
     parameter_server->parameter_descriptors.data[i].floating_point_range.data =
       allocator.zero_allocate(
@@ -674,10 +616,9 @@ rcl_ret_t init_parameter_server_memory_low(
   parameter_server->get_request.names.size = 0;
   parameter_server->get_request.names.capacity = 1;
 
-  parameter_server->get_request.names.data[0].data = allocator.allocate(
-    sizeof(char) * RCLC_PARAMETER_MAX_STRING_LENGTH, allocator.state);
-  parameter_server->get_request.names.data[0].capacity = RCLC_PARAMETER_MAX_STRING_LENGTH;
-  parameter_server->get_request.names.data[0].size = 0;
+  ret |= rclc_parameter_initialize_empty_string(
+    &parameter_server->get_request.names.data[0],
+    RCLC_PARAMETER_MAX_STRING_LENGTH);
 
   parameter_server->get_response.values.data = allocator.zero_allocate(
     1, sizeof(ParameterValue),
@@ -685,12 +626,8 @@ rcl_ret_t init_parameter_server_memory_low(
   parameter_server->get_response.values.size = 0;
   parameter_server->get_response.values.capacity = 1;
 
-  parameter_server->get_response.values.data[0].string_value.data = allocator.allocate(
-    sizeof(char),
-    allocator.state);
-  parameter_server->get_response.values.data[0].string_value.data[0] = '\0';
-  parameter_server->get_response.values.data[0].string_value.size = 0;
-  parameter_server->get_response.values.data[0].string_value.capacity = 1;
+  ret |= rclc_parameter_initialize_empty_string(
+    &parameter_server->get_response.values.data[0].string_value, 1);
 
   // Set parameters:
   //    - Only one parameter can be set, created or deleted per request
@@ -701,20 +638,18 @@ rcl_ret_t init_parameter_server_memory_low(
   parameter_server->set_request.parameters.size = 0;
   parameter_server->set_request.parameters.capacity = 1;
 
-  parameter_server->set_request.parameters.data[0].name.data = allocator.allocate(
-    sizeof(char) * RCLC_PARAMETER_MAX_STRING_LENGTH, allocator.state);
-  parameter_server->set_request.parameters.data[0].name.capacity = RCLC_PARAMETER_MAX_STRING_LENGTH;
-  parameter_server->set_request.parameters.data[0].name.size = 0;
+  ret |= rclc_parameter_initialize_empty_string(
+    &parameter_server->set_request.parameters.data[0].name,
+    RCLC_PARAMETER_MAX_STRING_LENGTH);
 
   parameter_server->set_response.results.data =
     allocator.zero_allocate(1, sizeof(SetParameters_Result), allocator.state);
   parameter_server->set_response.results.size = 0;
   parameter_server->set_response.results.capacity = 1;
 
-  parameter_server->set_response.results.data[0].reason.data = allocator.allocate(
-    sizeof(char) * RCLC_SET_ERROR_MAX_STRING_LENGTH, allocator.state);
-  parameter_server->set_response.results.data[0].reason.capacity = RCLC_SET_ERROR_MAX_STRING_LENGTH;
-  parameter_server->set_response.results.data[0].reason.size = 0;
+  ret |= rclc_parameter_initialize_empty_string(
+    &parameter_server->set_response.results.data[0].reason,
+    RCLC_SET_ERROR_MAX_STRING_LENGTH);
 
   // Get parameter types:
   //    - Only one parameter type can be retrieved per request
@@ -723,10 +658,9 @@ rcl_ret_t init_parameter_server_memory_low(
   parameter_server->get_types_request.names.size = 0;
   parameter_server->get_types_request.names.capacity = 1;
 
-  parameter_server->get_types_request.names.data[0].data = allocator.allocate(
-    sizeof(char) * RCLC_PARAMETER_MAX_STRING_LENGTH, allocator.state);
-  parameter_server->get_types_request.names.data[0].capacity = RCLC_PARAMETER_MAX_STRING_LENGTH;
-  parameter_server->get_types_request.names.data[0].size = 0;
+  ret |= rclc_parameter_initialize_empty_string(
+    &parameter_server->get_types_request.names.data[0],
+    RCLC_PARAMETER_MAX_STRING_LENGTH);
 
   parameter_server->get_types_response.types.data = allocator.zero_allocate(
     1, sizeof(uint8_t),
@@ -741,27 +675,20 @@ rcl_ret_t init_parameter_server_memory_low(
   parameter_server->describe_request.names.size = 0;
   parameter_server->describe_request.names.capacity = 1;
 
-  parameter_server->describe_request.names.data[0].data = allocator.allocate(
-    sizeof(char) * RCLC_PARAMETER_MAX_STRING_LENGTH, allocator.state);
-  parameter_server->describe_request.names.data[0].capacity = RCLC_PARAMETER_MAX_STRING_LENGTH;
-  parameter_server->describe_request.names.data[0].size = 0;
+  ret |= rclc_parameter_initialize_empty_string(
+    &parameter_server->describe_request.names.data[0],
+    RCLC_PARAMETER_MAX_STRING_LENGTH);
 
   parameter_server->describe_response.descriptors.data =
     allocator.zero_allocate(1, sizeof(ParameterDescriptor), allocator.state);
   parameter_server->describe_response.descriptors.size = 0;
   parameter_server->describe_response.descriptors.capacity = 1;
 
-  parameter_server->describe_response.descriptors.data[0].description.data =
-    allocator.allocate(sizeof(char), allocator.state);
-  parameter_server->describe_response.descriptors.data[0].description.data[0] = '\0';
-  parameter_server->describe_response.descriptors.data[0].description.capacity = 1;
-  parameter_server->describe_response.descriptors.data[0].description.size = 0;
-
-  parameter_server->describe_response.descriptors.data[0].additional_constraints.data =
-    allocator.allocate(sizeof(char), allocator.state);
-  parameter_server->describe_response.descriptors.data[0].additional_constraints.data[0] = '\0';
-  parameter_server->describe_response.descriptors.data[0].additional_constraints.capacity = 1;
-  parameter_server->describe_response.descriptors.data[0].additional_constraints.size = 0;
+  ret |= rclc_parameter_initialize_empty_string(
+    &parameter_server->describe_response.descriptors.data[0].description,
+    RCLC_PARAMETER_MAX_STRING_LENGTH);
+  ret |= rclc_parameter_initialize_empty_string(
+    &parameter_server->describe_response.descriptors.data[0].additional_constraints, 1);
 
   parameter_server->describe_response.descriptors.data[0].floating_point_range.data =
     allocator.zero_allocate(
@@ -817,7 +744,7 @@ rclc_parameter_server_init_with_option(
     rcl_interfaces,
     srv,
     GetParameters);
-  ret &= rclc_parameter_server_init_service(
+  ret |= rclc_parameter_server_init_service(
     &parameter_server->get_service, node, "/get_parameters",
     get_ts);
 
@@ -825,7 +752,7 @@ rclc_parameter_server_init_with_option(
     rcl_interfaces,
     srv,
     GetParameterTypes);
-  ret &= rclc_parameter_server_init_service(
+  ret |= rclc_parameter_server_init_service(
     &parameter_server->get_types_service, node,
     "/get_parameter_types", get_types_ts);
 
@@ -833,7 +760,7 @@ rclc_parameter_server_init_with_option(
     rcl_interfaces,
     srv,
     SetParameters);
-  ret &= rclc_parameter_server_init_service(
+  ret |= rclc_parameter_server_init_service(
     &parameter_server->set_service, node, "/set_parameters",
     set_ts);
 
@@ -841,7 +768,7 @@ rclc_parameter_server_init_with_option(
     rcl_interfaces,
     srv,
     ListParameters);
-  ret &= rclc_parameter_server_init_service(
+  ret |= rclc_parameter_server_init_service(
     &parameter_server->list_service, node,
     "/list_parameters", list_ts);
 
@@ -849,7 +776,7 @@ rclc_parameter_server_init_with_option(
     rcl_interfaces,
     srv,
     DescribeParameters);
-  ret &= rclc_parameter_server_init_service(
+  ret |= rclc_parameter_server_init_service(
     &parameter_server->describe_service, node,
     "/describe_parameters", describe_ts);
 
@@ -863,7 +790,7 @@ rclc_parameter_server_init_with_option(
       rcl_interfaces,
       msg,
       ParameterEvent);
-    ret &= rclc_publisher_init(
+    ret |= rclc_publisher_init(
       &parameter_server->event_publisher, node, event_ts,
       "/parameter_events",
       &rmw_qos_profile_parameter_events);
@@ -879,11 +806,11 @@ rclc_parameter_server_init_with_option(
 }
 
 void
-rclc_parameter_server_fini_memory_low_memory(
+rclc_parameter_server_fini_memory_low(
   rclc_parameter_server_t * parameter_server)
 {
   RCL_CHECK_FOR_NULL_WITH_MSG(
-    parameter_server, "parameter_server is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+    parameter_server, "parameter_server is a null pointer", return );
 
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
 
@@ -995,7 +922,7 @@ rclc_parameter_server_fini_memory(
   rclc_parameter_server_t * parameter_server)
 {
   RCL_CHECK_FOR_NULL_WITH_MSG(
-    parameter_server, "parameter_server is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+    parameter_server, "parameter_server is a null pointer", return );
 
   // Fini describe msgs
   for (size_t i = 0; i < parameter_server->describe_request.names.capacity; ++i) {
@@ -1097,18 +1024,18 @@ rclc_parameter_server_fini(
 
   rcl_ret_t ret = RCL_RET_OK;
 
-  ret &= rcl_service_fini(&parameter_server->list_service, node);
-  ret &= rcl_service_fini(&parameter_server->set_service, node);
-  ret &= rcl_service_fini(&parameter_server->get_service, node);
-  ret &= rcl_service_fini(&parameter_server->get_types_service, node);
-  ret &= rcl_service_fini(&parameter_server->describe_service, node);
+  ret |= rcl_service_fini(&parameter_server->list_service, node);
+  ret |= rcl_service_fini(&parameter_server->set_service, node);
+  ret |= rcl_service_fini(&parameter_server->get_service, node);
+  ret |= rcl_service_fini(&parameter_server->get_types_service, node);
+  ret |= rcl_service_fini(&parameter_server->describe_service, node);
 
   if (parameter_server->notify_changed_over_dds) {
-    ret &= rcl_publisher_fini(&parameter_server->event_publisher, node);
+    ret |= rcl_publisher_fini(&parameter_server->event_publisher, node);
   }
 
   if (parameter_server->low_mem_mode) {
-    rclc_parameter_server_fini_memory_low_memory(parameter_server);
+    rclc_parameter_server_fini_memory_low(parameter_server);
   } else {
     rclc_parameter_server_fini_memory(parameter_server);
   }
@@ -1620,9 +1547,11 @@ rcl_ret_t rclc_add_parameter_description(
   RCL_CHECK_FOR_NULL_WITH_MSG(
     parameter_name, "parameter_name is a null pointer", return RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_FOR_NULL_WITH_MSG(
-    parameter_description, "parameter_description is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+    parameter_description, "parameter_description is a null pointer",
+    return RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_FOR_NULL_WITH_MSG(
-    additional_constraints, "additional_constraints is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+    additional_constraints, "additional_constraints is a null pointer",
+    return RCL_RET_INVALID_ARGUMENT);
 
   if (parameter_server->low_mem_mode) {
     return RCLC_PARAMETER_UNSUPORTED_ON_LOW_MEM;
@@ -1757,10 +1686,6 @@ rcl_ret_t rclc_parameter_execute_callback(
 {
   RCL_CHECK_FOR_NULL_WITH_MSG(
     parameter_server, "parameter_server is a null pointer", return RCL_RET_INVALID_ARGUMENT);
-  RCL_CHECK_FOR_NULL_WITH_MSG(
-    old_param, "old_param is a null pointer", return RCL_RET_INVALID_ARGUMENT);
-  RCL_CHECK_FOR_NULL_WITH_MSG(
-    new_param, "new_param is a null pointer", return RCL_RET_INVALID_ARGUMENT);
 
   bool ret = true;
 

--- a/rclc_parameter/src/rclc_parameter/parameter_server.c
+++ b/rclc_parameter/src/rclc_parameter/parameter_server.c
@@ -745,14 +745,13 @@ rclc_add_parameter_undeclared(
     return RCL_RET_ERROR;
   }
 
-  if (!rclc_parameter_set_string(
-      &parameter_server->parameter_list.data[index].name,
-      parameter->name.data))
+  if (RCL_RET_OK != rclc_parameter_copy(
+    &parameter_server->parameter_list.data[index],
+    parameter))
   {
     return RCL_RET_ERROR;
   }
 
-  parameter_server->parameter_list.data[index].value = parameter->value;
   parameter_server->parameter_list.size++;
 
   // Add to parameter descriptors
@@ -764,7 +763,7 @@ rclc_add_parameter_undeclared(
   }
 
   parameter_server->parameter_descriptors.data[index].type =
-    parameter_server->parameter_list.data[index].value.type;
+    parameter->value.type;
   parameter_server->parameter_descriptors.size++;
 
   if (parameter_server->notify_changed_over_dds) {

--- a/rclc_parameter/src/rclc_parameter/parameter_server.c
+++ b/rclc_parameter/src/rclc_parameter/parameter_server.c
@@ -53,6 +53,13 @@ rclc_parameter_server_describe_service_callback(
   void * res,
   void * parameter_server)
 {
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    req, "req is a null pointer", return);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    res, "res is a null pointer", return);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    parameter_server, "parameter_server is a null pointer", return);
+
   rclc_parameter_server_t * param_server = (rclc_parameter_server_t *) parameter_server;
   DescribeParameters_Request * request = (DescribeParameters_Request *) req;
   DescribeParameters_Response * response = (DescribeParameters_Response *) res;
@@ -103,6 +110,11 @@ rclc_parameter_server_list_service_callback(
   void * res,
   void * parameter_server)
 {
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    res, "res is a null pointer", return);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    parameter_server, "parameter_server is a null pointer", return);
+
   (void) req;
 
   rclc_parameter_server_t * param_server = (rclc_parameter_server_t *) parameter_server;
@@ -127,6 +139,13 @@ rclc_parameter_server_get_service_callback(
   void * res,
   void * parameter_server)
 {
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    req, "req is a null pointer", return);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    res, "res is a null pointer", return);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    parameter_server, "parameter_server is a null pointer", return);
+
   const GetParameters_Request * request = (const GetParameters_Request *) req;
   GetParameters_Response * response = (GetParameters_Response *) res;
   rclc_parameter_server_t * param_server = (rclc_parameter_server_t *) parameter_server;
@@ -161,6 +180,13 @@ rclc_parameter_server_get_types_service_callback(
   void * res,
   void * parameter_server)
 {
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    req, "req is a null pointer", return);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    res, "res is a null pointer", return);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    parameter_server, "parameter_server is a null pointer", return);
+
   const GetParameterTypes_Request * request = (const GetParameterTypes_Request *)  req;
   GetParameterTypes_Response * response = (GetParameterTypes_Response *) res;
   rclc_parameter_server_t * param_server = (rclc_parameter_server_t *) parameter_server;
@@ -191,6 +217,13 @@ rclc_parameter_server_set_service_callback(
   void * res,
   void * parameter_server)
 {
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    req, "req is a null pointer", return);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    res, "res is a null pointer", return);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    parameter_server, "parameter_server is a null pointer", return);
+
   const SetParameters_Request * request = (const SetParameters_Request *) req;
   SetParameters_Response * response = (SetParameters_Response *) res;
   rclc_parameter_server_t * param_server = (rclc_parameter_server_t *) parameter_server;
@@ -535,11 +568,18 @@ init_parameter_server_memory(
   return ret;
 }
 
-bool init_parameter_server_memory_low_memory(
+rcl_ret_t init_parameter_server_memory_low(
   rclc_parameter_server_t * parameter_server,
   rcl_node_t * node,
   const rclc_parameter_options_t * options)
 {
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    parameter_server, "parameter_server is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    node, "node is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    options, "options is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+
   rcl_ret_t ret = RCL_RET_OK;
 
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
@@ -830,9 +870,9 @@ rclc_parameter_server_init_with_option(
   }
 
   if (parameter_server->low_mem_mode) {
-    ret = init_parameter_server_memory_low_memory(parameter_server, node, options);
+    ret |= init_parameter_server_memory_low(parameter_server, node, options);
   } else {
-    ret = init_parameter_server_memory(parameter_server, node, options);
+    ret |= init_parameter_server_memory(parameter_server, node, options);
   }
 
   return ret;
@@ -842,6 +882,9 @@ void
 rclc_parameter_server_fini_memory_low_memory(
   rclc_parameter_server_t * parameter_server)
 {
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    parameter_server, "parameter_server is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
 
   // Get request
@@ -951,6 +994,9 @@ void
 rclc_parameter_server_fini_memory(
   rclc_parameter_server_t * parameter_server)
 {
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    parameter_server, "parameter_server is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+
   // Fini describe msgs
   for (size_t i = 0; i < parameter_server->describe_request.names.capacity; ++i) {
     rosidl_runtime_c__String__fini(&parameter_server->describe_request.names.data[i]);
@@ -1519,6 +1565,9 @@ rcl_ret_t
 rclc_parameter_service_publish_event(
   rclc_parameter_server_t * parameter_server)
 {
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    parameter_server, "parameter_server is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+
   rcl_ret_t ret = RCL_RET_OK;
 
   rcutils_time_point_value_t now;
@@ -1542,6 +1591,15 @@ rclc_parameter_server_init_service(
   char * service_name,
   const rosidl_service_type_support_t * srv_type)
 {
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    service, "service is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    node, "node is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    service_name, "service_name is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    srv_type, "srv_type is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+
   const char * node_name = rcl_node_get_name(node);
 
   static char get_service_name[RCLC_PARAMETER_MAX_STRING_LENGTH];
@@ -1557,6 +1615,15 @@ rcl_ret_t rclc_add_parameter_description(
   const char * parameter_description,
   const char * additional_constraints)
 {
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    parameter_server, "parameter_server is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    parameter_name, "parameter_name is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    parameter_description, "parameter_description is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    additional_constraints, "additional_constraints is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+
   if (parameter_server->low_mem_mode) {
     return RCLC_PARAMETER_UNSUPORTED_ON_LOW_MEM;
   }
@@ -1590,6 +1657,11 @@ rcl_ret_t rclc_set_parameter_read_only(
   const char * parameter_name,
   bool read_only)
 {
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    parameter_server, "parameter_server is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    parameter_name, "parameter_name is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+
   if (parameter_server->on_callback) {
     return RCLC_PARAMETER_DISABLED_ON_CALLBACK;
   }
@@ -1615,6 +1687,11 @@ rcl_ret_t rclc_add_parameter_constraint_double(
   double to_value,
   double step)
 {
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    parameter_server, "parameter_server is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    parameter_name, "parameter_name is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+
   if (parameter_server->on_callback) {
     return RCLC_PARAMETER_DISABLED_ON_CALLBACK;
   }
@@ -1644,6 +1721,11 @@ rcl_ret_t rclc_add_parameter_constraint_integer(
   const char * parameter_name, int64_t from_value,
   int64_t to_value, uint64_t step)
 {
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    parameter_server, "parameter_server is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    parameter_name, "parameter_name is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+
   if (parameter_server->on_callback) {
     return RCLC_PARAMETER_DISABLED_ON_CALLBACK;
   }
@@ -1673,6 +1755,13 @@ rcl_ret_t rclc_parameter_execute_callback(
   const Parameter * old_param,
   const Parameter * new_param)
 {
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    parameter_server, "parameter_server is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    old_param, "old_param is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    new_param, "new_param is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+
   bool ret = true;
 
   if (parameter_server->on_modification) {

--- a/rclc_parameter/src/rclc_parameter/parameter_server.c
+++ b/rclc_parameter/src/rclc_parameter/parameter_server.c
@@ -325,8 +325,9 @@ init_parameter_server_memory(
   rcl_ret_t ret = RCL_RET_OK;
 
   static char empty_string[RCLC_PARAMETER_MAX_STRING_LENGTH];
-  memset(empty_string, ' ', RCLC_PARAMETER_MAX_STRING_LENGTH);
+  memset(empty_string, '\0', RCLC_PARAMETER_MAX_STRING_LENGTH);
   empty_string[RCLC_PARAMETER_MAX_STRING_LENGTH - 1] = '\0';
+  size_t empty_string_capacity = RCLC_PARAMETER_MAX_STRING_LENGTH - 1;
 
   bool mem_allocs_ok = true;
   mem_allocs_ok &= rcl_interfaces__msg__Parameter__Sequence__init(
@@ -336,9 +337,10 @@ init_parameter_server_memory(
 
   // Pre-init strings
   for (size_t i = 0; i < options->max_params; i++) {
-    mem_allocs_ok &= rosidl_runtime_c__String__assign(
+    mem_allocs_ok &= rosidl_runtime_c__String__assignn(
       &parameter_server->parameter_list.data[i].name,
-      (const char *) empty_string);
+      (const char *) empty_string,
+      empty_string_capacity);
   }
 
   // Init list service msgs
@@ -353,9 +355,10 @@ init_parameter_server_memory(
 
   // Pre-init strings
   for (size_t i = 0; i < options->max_params; i++) {
-    mem_allocs_ok &= rosidl_runtime_c__String__assign(
+    mem_allocs_ok &= rosidl_runtime_c__String__assignn(
       &parameter_server->list_response.result.names.data[i],
-      (const char *) empty_string);
+      (const char *) empty_string,
+      empty_string_capacity);
   }
 
   // Init Get service msgs
@@ -373,9 +376,10 @@ init_parameter_server_memory(
 
   // Pre-init strings
   for (size_t i = 0; i < options->max_params; i++) {
-    mem_allocs_ok &= rosidl_runtime_c__String__assign(
+    mem_allocs_ok &= rosidl_runtime_c__String__assignn(
       &parameter_server->get_request.names.data[i],
-      (const char *) empty_string);
+      (const char *) empty_string,
+      empty_string_capacity);
   }
 
   // Init Set service msgs
@@ -392,18 +396,21 @@ init_parameter_server_memory(
   parameter_server->set_response.results.size = 0;
 
   static char empty_string_reason[RCLC_SET_ERROR_MAX_STRING_LENGTH];
-  memset(empty_string_reason, ' ', RCLC_SET_ERROR_MAX_STRING_LENGTH);
+  memset(empty_string_reason, '\0', RCLC_SET_ERROR_MAX_STRING_LENGTH);
   empty_string_reason[RCLC_SET_ERROR_MAX_STRING_LENGTH - 1] = '\0';
+  size_t string_reason_capacity = RCLC_SET_ERROR_MAX_STRING_LENGTH - 1;
 
   // Pre-init strings
   for (size_t i = 0; i < options->max_params; i++) {
-    mem_allocs_ok &= rosidl_runtime_c__String__assign(
+    mem_allocs_ok &= rosidl_runtime_c__String__assignn(
       &parameter_server->set_request.parameters.data[i].name,
-      (const char *) empty_string);
+      (const char *) empty_string,
+      empty_string_capacity);
 
-    mem_allocs_ok &= rosidl_runtime_c__String__assign(
+    mem_allocs_ok &= rosidl_runtime_c__String__assignn(
       &parameter_server->set_response.results.data[i].reason,
-      (const char *) empty_string_reason);
+      (const char *) empty_string_reason,
+      string_reason_capacity);
   }
 
   // Init Get types service msgs
@@ -421,9 +428,10 @@ init_parameter_server_memory(
   parameter_server->get_types_response.types.size = 0;
 
   for (size_t i = 0; i < options->max_params; i++) {
-    mem_allocs_ok &= rosidl_runtime_c__String__assign(
+    mem_allocs_ok &= rosidl_runtime_c__String__assignn(
       &parameter_server->get_types_request.names.data[i],
-      (const char *) empty_string);
+      (const char *) empty_string,
+      empty_string_capacity);
   }
 
   // Init Describe service msgs
@@ -448,20 +456,24 @@ init_parameter_server_memory(
 
   for (size_t i = 0; i < options->max_params; i++) {
     // Init describe_request members
-    mem_allocs_ok &= rosidl_runtime_c__String__assign(
+    mem_allocs_ok &= rosidl_runtime_c__String__assignn(
       &parameter_server->describe_request.names.data[i],
-      (const char *) empty_string);
+      (const char *) empty_string,
+      empty_string_capacity);
 
     // Init describe_response members
-    mem_allocs_ok &= rosidl_runtime_c__String__assign(
+    mem_allocs_ok &= rosidl_runtime_c__String__assignn(
       &parameter_server->describe_response.descriptors.data[i].name,
-      (const char *) empty_string);
-    mem_allocs_ok &= rosidl_runtime_c__String__assign(
+      (const char *) empty_string,
+      empty_string_capacity);
+    mem_allocs_ok &= rosidl_runtime_c__String__assignn(
       &parameter_server->describe_response.descriptors.data[i].description,
-      (const char *) empty_string);
-    mem_allocs_ok &= rosidl_runtime_c__String__assign(
+      (const char *) empty_string,
+      empty_string_capacity);
+    mem_allocs_ok &= rosidl_runtime_c__String__assignn(
       &parameter_server->describe_response.descriptors.data[i].additional_constraints,
-      (const char *) empty_string);
+      (const char *) empty_string,
+      empty_string_capacity);
     mem_allocs_ok &= rcl_interfaces__msg__FloatingPointRange__Sequence__init(
       &parameter_server->describe_response.descriptors.data[i].floating_point_range,
       rcl_interfaces__msg__ParameterDescriptor__floating_point_range__MAX_SIZE);
@@ -472,15 +484,18 @@ init_parameter_server_memory(
     parameter_server->describe_response.descriptors.data[i].integer_range.size = 0;
 
     // Init parameter_descriptors members
-    mem_allocs_ok &= rosidl_runtime_c__String__assign(
+    mem_allocs_ok &= rosidl_runtime_c__String__assignn(
       &parameter_server->parameter_descriptors.data[i].name,
-      (const char *) empty_string);
-    mem_allocs_ok &= rosidl_runtime_c__String__assign(
+      (const char *) empty_string,
+      empty_string_capacity);
+    mem_allocs_ok &= rosidl_runtime_c__String__assignn(
       &parameter_server->parameter_descriptors.data[i].description,
-      (const char *) empty_string);
-    mem_allocs_ok &= rosidl_runtime_c__String__assign(
+      (const char *) empty_string,
+      empty_string_capacity);
+    mem_allocs_ok &= rosidl_runtime_c__String__assignn(
       &parameter_server->parameter_descriptors.data[i].additional_constraints,
-      (const char *) empty_string);
+      (const char *) empty_string,
+      empty_string_capacity);
     mem_allocs_ok &= rcl_interfaces__msg__FloatingPointRange__Sequence__init(
       &parameter_server->parameter_descriptors.data[i].floating_point_range,
       rcl_interfaces__msg__ParameterDescriptor__floating_point_range__MAX_SIZE);
@@ -1199,6 +1214,11 @@ rclc_delete_parameter(
 
   Parameter * param = &parameter_server->parameter_list.data[index];
   ParameterDescriptor * param_description = &parameter_server->parameter_descriptors.data[index];
+
+  if (parameter_server->notify_changed_over_dds) {
+    rclc_parameter_prepare_deleted_event(&parameter_server->event_list, param);
+    rclc_parameter_service_publish_event(parameter_server);
+  }
 
   // Reset parameter
   rclc_parameter_set_string(&param->name, "");

--- a/rclc_parameter/src/rclc_parameter/parameter_server.c
+++ b/rclc_parameter/src/rclc_parameter/parameter_server.c
@@ -805,8 +805,8 @@ rclc_delete_parameter(
   rclc_parameter_set_string(&param_description->description, "");
   rclc_parameter_set_string(&param_description->additional_constraints, "");
   param_description->type = RCLC_PARAMETER_NOT_SET;
-  parameter_descriptor->floating_point_range.size = 0;
-  parameter_descriptor->integer_range.size = 0;
+  param_description->floating_point_range.size = 0;
+  param_description->integer_range.size = 0;
 
   for (size_t i = index; i < (parameter_server->parameter_list.size - 1); i++) {
     // Move parameter list

--- a/rclc_parameter/src/rclc_parameter/parameter_server.c
+++ b/rclc_parameter/src/rclc_parameter/parameter_server.c
@@ -52,7 +52,13 @@ rclc_parameter_server_describe_service_callback(
   DescribeParameters_Request * request = (DescribeParameters_Request *) req;
   DescribeParameters_Response * response = (DescribeParameters_Response *) res;
 
+  if (request->names.size > response->descriptors.capacity) {
+    response->descriptors.size = 0;
+    return;
+  }
+
   response->descriptors.size = request->names.size;
+
   for (size_t i = 0; i < request->names.size; i++) {
     size_t index = rclc_parameter_search_index(
       &param_server->parameter_list,
@@ -60,17 +66,28 @@ rclc_parameter_server_describe_service_callback(
 
     ParameterDescriptor * response_descriptor = &response->descriptors.data[i];
 
+    // Reset response values
+    response_descriptor->type = RCLC_PARAMETER_NOT_SET;
+    response_descriptor->read_only = false;
+    response_descriptor->floating_point_range.size = 0;
+    response_descriptor->integer_range.size = 0;
+
+    // Copy request name
+    if (param_server->low_mem_mode) {
+      response_descriptor->name.data = request->names.data[i].data;
+      response_descriptor->name.size = request->names.data[i].size;
+      response_descriptor->name.capacity = request->names.data[i].capacity;
+    }
+
     if (index < param_server->parameter_descriptors.size) {
       ParameterDescriptor * parameter_descriptor = &param_server->parameter_descriptors.data[index];
-      rclc_parameter_descriptor_copy(response_descriptor, parameter_descriptor);
-    } else {
-      rclc_parameter_set_string(&response_descriptor->name, "");
+      rclc_parameter_descriptor_copy(
+        response_descriptor, parameter_descriptor,
+        param_server->low_mem_mode);
+    } else if (!param_server->low_mem_mode) {
+      rclc_parameter_set_string(&response_descriptor->name, request->names.data[i].data);
       rclc_parameter_set_string(&response_descriptor->description, "");
       rclc_parameter_set_string(&response_descriptor->additional_constraints, "");
-      response_descriptor->type = RCLC_PARAMETER_NOT_SET;
-      response_descriptor->read_only = false;
-      response_descriptor->floating_point_range.size = 0;
-      response_descriptor->integer_range.size = 0;
     }
   }
 }
@@ -89,9 +106,13 @@ rclc_parameter_server_list_service_callback(
   response->result.names.size = param_server->parameter_list.size;
 
   for (size_t i = 0; i < response->result.names.size; i++) {
-    rclc_parameter_set_string(
-      &response->result.names.data[i],
-      param_server->parameter_list.data[i].name.data);
+    if (!param_server->low_mem_mode) {
+      rclc_parameter_set_string(
+        &response->result.names.data[i],
+        param_server->parameter_list.data[i].name.data);
+    } else {
+      response->result.names.data[i].size = param_server->parameter_list.data[i].name.size;
+    }
   }
 }
 
@@ -104,6 +125,11 @@ rclc_parameter_server_get_service_callback(
   const GetParameters_Request * request = (const GetParameters_Request *) req;
   GetParameters_Response * response = (GetParameters_Response *) res;
   rclc_parameter_server_t * param_server = (rclc_parameter_server_t *) parameter_server;
+
+  if (request->names.size > response->values.capacity) {
+    response->values.size = 0;
+    return;
+  }
 
   size_t size = (request->names.size > param_server->parameter_list.size) ?
     param_server->parameter_list.size :
@@ -174,16 +200,24 @@ rclc_parameter_server_set_service_callback(
   for (size_t i = 0; i < response->results.size; i++) {
     rosidl_runtime_c__String * message =
       (rosidl_runtime_c__String *) &response->results.data[i].reason;
-    Parameter * parameter = rclc_parameter_search(
+    size_t index = rclc_parameter_search_index(
       &param_server->parameter_list,
       request->parameters.data[i].name.data);
+
     rcl_ret_t ret = RCL_RET_OK;
 
     // Clean previous response msg
     response->results.data[i].successful = false;
     rclc_parameter_set_string(message, "");
 
-    if (parameter != NULL) {
+    if (index < param_server->parameter_list.size) {
+      if (param_server->parameter_descriptors.data[index].read_only) {
+        rclc_parameter_set_string(message, "Read only parameter");
+        continue;
+      }
+
+      Parameter * parameter = &param_server->parameter_list.data[index];
+
       switch (request->parameters.data[i].value.type) {
         case RCLC_PARAMETER_NOT_SET:
           if (param_server->on_modification && !param_server->on_modification(parameter, NULL)) {
@@ -259,6 +293,7 @@ const rclc_parameter_options_t DEFAULT_PARAMETER_SERVER_OPTIONS = {
   .notify_changed_over_dds = true,
   .max_params = 4,
   .allow_undeclared_parameters = false,
+  .low_mem_mode = false
 };
 
 rcl_ret_t rclc_parameter_server_init_default(
@@ -275,7 +310,7 @@ rcl_ret_t rclc_parameter_server_init_default(
 }
 
 rcl_ret_t
-rclc_parameter_server_init_with_option(
+init_parameter_server_memory(
   rclc_parameter_server_t * parameter_server,
   rcl_node_t * node,
   const rclc_parameter_options_t * options)
@@ -288,56 +323,6 @@ rclc_parameter_server_init_with_option(
     options, "options is a null pointer", return RCL_RET_INVALID_ARGUMENT);
 
   rcl_ret_t ret = RCL_RET_OK;
-
-  const rosidl_service_type_support_t * get_ts = ROSIDL_GET_SRV_TYPE_SUPPORT(
-    rcl_interfaces, srv,
-    GetParameters);
-  ret |= rclc_parameter_server_init_service(
-    &parameter_server->get_service, node, "/get_parameters",
-    get_ts);
-
-  const rosidl_service_type_support_t * get_types_ts = ROSIDL_GET_SRV_TYPE_SUPPORT(
-    rcl_interfaces,
-    srv,
-    GetParameterTypes);
-  ret |= rclc_parameter_server_init_service(
-    &parameter_server->get_types_service, node,
-    "/get_parameter_types", get_types_ts);
-
-  const rosidl_service_type_support_t * set_ts = ROSIDL_GET_SRV_TYPE_SUPPORT(
-    rcl_interfaces, srv,
-    SetParameters);
-  ret |= rclc_parameter_server_init_service(
-    &parameter_server->set_service, node, "/set_parameters",
-    set_ts);
-
-  const rosidl_service_type_support_t * list_ts = ROSIDL_GET_SRV_TYPE_SUPPORT(
-    rcl_interfaces, srv,
-    ListParameters);
-  ret |= rclc_parameter_server_init_service(
-    &parameter_server->list_service, node,
-    "/list_parameters", list_ts);
-
-  const rosidl_service_type_support_t * describe_ts = ROSIDL_GET_SRV_TYPE_SUPPORT(
-    rcl_interfaces, srv,
-    DescribeParameters);
-  ret |= rclc_parameter_server_init_service(
-    &parameter_server->describe_service, node,
-    "/describe_parameters", describe_ts);
-
-  parameter_server->notify_changed_over_dds = options->notify_changed_over_dds;
-  parameter_server->allow_undeclared_parameters = options->allow_undeclared_parameters;
-
-  if (parameter_server->notify_changed_over_dds) {
-    const rosidl_message_type_support_t * event_ts = ROSIDL_GET_MSG_TYPE_SUPPORT(
-      rcl_interfaces,
-      msg,
-      ParameterEvent);
-    ret |= rclc_publisher_init(
-      &parameter_server->event_publisher, node, event_ts,
-      "/parameter_events",
-      &rmw_qos_profile_parameter_events);
-  }
 
   static char empty_string[RCLC_PARAMETER_MAX_STRING_LENGTH];
   memset(empty_string, ' ', RCLC_PARAMETER_MAX_STRING_LENGTH);
@@ -521,30 +506,405 @@ rclc_parameter_server_init_with_option(
   return ret;
 }
 
-rcl_ret_t
-rclc_parameter_server_fini(
+bool init_parameter_server_memory_low_memory(
   rclc_parameter_server_t * parameter_server,
-  rcl_node_t * node)
+  rcl_node_t * node,
+  const rclc_parameter_options_t * options)
+{
+  rcl_ret_t ret = RCL_RET_OK;
+
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+
+  // Init a parameter sequence
+  parameter_server->parameter_list.data =
+    allocator.zero_allocate(options->max_params, sizeof(Parameter), allocator.state);
+  parameter_server->parameter_list.size = 0;
+  parameter_server->parameter_list.capacity = options->max_params;
+
+  // Init a parameter descriptor sequence
+  parameter_server->parameter_descriptors.data = allocator.zero_allocate(
+    options->max_params,
+    sizeof(ParameterDescriptor),
+    allocator.state);
+  parameter_server->parameter_descriptors.size = 0;
+  parameter_server->parameter_descriptors.capacity = options->max_params;
+
+  for (size_t i = 0; i < options->max_params; i++) {
+    parameter_server->parameter_list.data[i].name.data = allocator.allocate(
+      sizeof(char) * RCLC_PARAMETER_MAX_STRING_LENGTH, allocator.state);
+    parameter_server->parameter_list.data[i].name.data[0] = '\0';
+    parameter_server->parameter_list.data[i].name.capacity = RCLC_PARAMETER_MAX_STRING_LENGTH;
+    parameter_server->parameter_list.data[i].name.size = 0;
+
+    parameter_server->parameter_list.data[i].value.string_value.data =
+      allocator.allocate(sizeof(char), allocator.state);
+    parameter_server->parameter_list.data[i].value.string_value.data[0] = '\0';
+    parameter_server->parameter_list.data[i].value.string_value.capacity = 1;
+    parameter_server->parameter_list.data[i].value.string_value.size = 0;
+
+    parameter_server->parameter_descriptors.data[i].description.data =
+      allocator.allocate(sizeof(char), allocator.state);
+    parameter_server->parameter_descriptors.data[i].description.data[0] = '\0';
+    parameter_server->parameter_descriptors.data[i].description.capacity = 1;
+    parameter_server->parameter_descriptors.data[i].description.size = 0;
+
+    parameter_server->parameter_descriptors.data[i].additional_constraints.data =
+      allocator.allocate(sizeof(char), allocator.state);
+    parameter_server->parameter_descriptors.data[i].additional_constraints.data[0] = '\0';
+    parameter_server->parameter_descriptors.data[i].additional_constraints.capacity = 1;
+    parameter_server->parameter_descriptors.data[i].additional_constraints.size = 0;
+
+    parameter_server->parameter_descriptors.data[i].floating_point_range.data =
+      allocator.zero_allocate(
+      1, sizeof(rcl_interfaces__msg__FloatingPointRange__Sequence),
+      allocator.state);
+    parameter_server->parameter_descriptors.data[i].floating_point_range.capacity = 1;
+    parameter_server->parameter_descriptors.data[i].floating_point_range.size = 0;
+
+    parameter_server->parameter_descriptors.data[i].integer_range.data = allocator.zero_allocate(
+      1,
+      sizeof(
+        rcl_interfaces__msg__IntegerRange__Sequence), allocator.state);
+    parameter_server->parameter_descriptors.data[i].integer_range.capacity = 1;
+    parameter_server->parameter_descriptors.data[i].integer_range.size = 0;
+  }
+
+  // Parameter descriptors
+
+  // Initialize empty string value
+
+  // List parameters:
+  //    - The request has no prefixes enabled nor depth.
+  //    - The response has a sequence of names taken from the names of each parameter
+  parameter_server->list_request.prefixes.data = NULL;
+  parameter_server->list_request.prefixes.size = 0;
+  parameter_server->list_request.prefixes.capacity = 0;
+
+  parameter_server->list_response.result.names.data =
+    allocator.allocate(sizeof(rosidl_runtime_c__String) * options->max_params, allocator.state);
+  parameter_server->list_response.result.names.size = 0;
+  parameter_server->list_response.result.names.capacity = options->max_params;
+  for (size_t i = 0; i < options->max_params; i++) {
+    parameter_server->list_response.result.names.data[i].data =
+      parameter_server->parameter_list.data[i].name.data;
+    parameter_server->list_response.result.names.data[i].capacity =
+      parameter_server->parameter_list.data[i].name.capacity;
+    parameter_server->list_response.result.names.data[i].size =
+      parameter_server->parameter_list.data[i].name.size;
+  }
+
+  parameter_server->list_response.result.prefixes.data = NULL;
+  parameter_server->list_response.result.prefixes.size = 0;
+  parameter_server->list_response.result.prefixes.capacity = 0;
+
+  // Get parameters:
+  //    - Only one parameter can be retrieved per request
+  parameter_server->get_request.names.data = allocator.allocate(
+    sizeof(rosidl_runtime_c__String),
+    allocator.state);
+  parameter_server->get_request.names.size = 0;
+  parameter_server->get_request.names.capacity = 1;
+
+  parameter_server->get_request.names.data[0].data = allocator.allocate(
+    sizeof(char) * RCLC_PARAMETER_MAX_STRING_LENGTH, allocator.state);
+  parameter_server->get_request.names.data[0].capacity = RCLC_PARAMETER_MAX_STRING_LENGTH;
+  parameter_server->get_request.names.data[0].size = 0;
+
+  parameter_server->get_response.values.data = allocator.zero_allocate(
+    1, sizeof(ParameterValue),
+    allocator.state);
+  parameter_server->get_response.values.size = 0;
+  parameter_server->get_response.values.capacity = 1;
+
+  parameter_server->get_response.values.data[0].string_value.data = allocator.allocate(
+    sizeof(char),
+    allocator.state);
+  parameter_server->get_response.values.data[0].string_value.data[0] = '\0';
+  parameter_server->get_response.values.data[0].string_value.size = 0;
+  parameter_server->get_response.values.data[0].string_value.capacity = 1;
+
+  // Set parameters:
+  //    - Only one parameter can be set, created or deleted per request
+  // TODO(acuadros95): Check if alloc ParameterValue string_value
+  parameter_server->set_request.parameters.data = allocator.zero_allocate(
+    1, sizeof(Parameter),
+    allocator.state);
+  parameter_server->set_request.parameters.size = 0;
+  parameter_server->set_request.parameters.capacity = 1;
+
+  parameter_server->set_request.parameters.data[0].name.data = allocator.allocate(
+    sizeof(char) * RCLC_PARAMETER_MAX_STRING_LENGTH, allocator.state);
+  parameter_server->set_request.parameters.data[0].name.capacity = RCLC_PARAMETER_MAX_STRING_LENGTH;
+  parameter_server->set_request.parameters.data[0].name.size = 0;
+
+  parameter_server->set_response.results.data =
+    allocator.zero_allocate(1, sizeof(SetParameters_Result), allocator.state);
+  parameter_server->set_response.results.size = 0;
+  parameter_server->set_response.results.capacity = 1;
+
+  parameter_server->set_response.results.data[0].reason.data = allocator.allocate(
+    sizeof(char) * RCLC_PARAMETER_MAX_STRING_LENGTH, allocator.state);
+  parameter_server->set_response.results.data[0].reason.capacity = RCLC_PARAMETER_MAX_STRING_LENGTH;
+  parameter_server->set_response.results.data[0].reason.size = 0;
+
+  // Get parameter types:
+  //    - Only one parameter type can be retrieved per request
+  parameter_server->get_types_request.names.data =
+    allocator.allocate(sizeof(rosidl_runtime_c__String), allocator.state);
+  parameter_server->get_types_request.names.size = 0;
+  parameter_server->get_types_request.names.capacity = 1;
+
+  parameter_server->get_types_request.names.data[0].data = allocator.allocate(
+    sizeof(char) * RCLC_PARAMETER_MAX_STRING_LENGTH, allocator.state);
+  parameter_server->get_types_request.names.data[0].capacity = RCLC_PARAMETER_MAX_STRING_LENGTH;
+  parameter_server->get_types_request.names.data[0].size = 0;
+
+  parameter_server->get_types_response.types.data = allocator.zero_allocate(
+    1, sizeof(uint8_t),
+    allocator.state);
+  parameter_server->get_types_response.types.size = 0;
+  parameter_server->get_types_response.types.capacity = 1;
+
+  // Describe parameters:
+  //    - Only one description can be retrieved per request
+  parameter_server->describe_request.names.data = allocator.allocate(
+    sizeof(rosidl_runtime_c__String), allocator.state);
+  parameter_server->describe_request.names.size = 0;
+  parameter_server->describe_request.names.capacity = 1;
+
+  parameter_server->describe_request.names.data[0].data = allocator.allocate(
+    sizeof(char) * RCLC_PARAMETER_MAX_STRING_LENGTH, allocator.state);
+  parameter_server->describe_request.names.data[0].capacity = RCLC_PARAMETER_MAX_STRING_LENGTH;
+  parameter_server->describe_request.names.data[0].size = 0;
+
+  parameter_server->describe_response.descriptors.data =
+    allocator.zero_allocate(1, sizeof(ParameterDescriptor), allocator.state);
+  parameter_server->describe_response.descriptors.size = 0;
+  parameter_server->describe_response.descriptors.capacity = 1;
+
+  parameter_server->describe_response.descriptors.data[0].description.data =
+    allocator.allocate(sizeof(char), allocator.state);
+  parameter_server->describe_response.descriptors.data[0].description.data[0] = '\0';
+  parameter_server->describe_response.descriptors.data[0].description.capacity = 1;
+  parameter_server->describe_response.descriptors.data[0].description.size = 0;
+
+  parameter_server->describe_response.descriptors.data[0].additional_constraints.data =
+    allocator.allocate(sizeof(char), allocator.state);
+  parameter_server->describe_response.descriptors.data[0].additional_constraints.data[0] = '\0';
+  parameter_server->describe_response.descriptors.data[0].additional_constraints.capacity = 1;
+  parameter_server->describe_response.descriptors.data[0].additional_constraints.size = 0;
+
+  parameter_server->describe_response.descriptors.data[0].floating_point_range.data =
+    allocator.zero_allocate(
+    1, sizeof(rcl_interfaces__msg__FloatingPointRange__Sequence),
+    allocator.state);
+  parameter_server->describe_response.descriptors.data[0].floating_point_range.capacity = 1;
+  parameter_server->describe_response.descriptors.data[0].floating_point_range.size = 0;
+
+  parameter_server->describe_response.descriptors.data[0].integer_range.data =
+    allocator.zero_allocate(
+    1,
+    sizeof(
+      rcl_interfaces__msg__IntegerRange__Sequence), allocator.state);
+  parameter_server->describe_response.descriptors.data[0].integer_range.capacity = 1;
+  parameter_server->describe_response.descriptors.data[0].integer_range.size = 0;
+
+  // Parameter events msg
+  if (parameter_server->notify_changed_over_dds) {
+    // Parameter node info
+    parameter_server->event_list.node.data = (char *) rcl_node_get_name(node);
+    parameter_server->event_list.node.size = strlen(rcl_node_get_name(node));
+    parameter_server->event_list.node.capacity = parameter_server->event_list.node.size + 1;
+
+    // Parameters event
+    parameter_server->event_list.new_parameters.size = 0;
+    parameter_server->event_list.new_parameters.capacity = 1;
+    parameter_server->event_list.changed_parameters.size = 0;
+    parameter_server->event_list.changed_parameters.capacity = 1;
+    parameter_server->event_list.deleted_parameters.size = 0;
+    parameter_server->event_list.deleted_parameters.capacity = 1;
+  }
+
+  return ret;
+}
+
+rcl_ret_t
+rclc_parameter_server_init_with_option(
+  rclc_parameter_server_t * parameter_server,
+  rcl_node_t * node,
+  const rclc_parameter_options_t * options)
 {
   RCL_CHECK_FOR_NULL_WITH_MSG(
     parameter_server, "parameter is a null pointer", return RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_FOR_NULL_WITH_MSG(
     node, "node is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    options, "options is a null pointer", return RCL_RET_INVALID_ARGUMENT);
 
   rcl_ret_t ret = RCL_RET_OK;
 
-  ret |= rcl_service_fini(&parameter_server->list_service, node);
-  ret |= rcl_service_fini(&parameter_server->set_service, node);
-  ret |= rcl_service_fini(&parameter_server->get_service, node);
-  ret |= rcl_service_fini(&parameter_server->get_types_service, node);
-  ret |= rcl_service_fini(&parameter_server->describe_service, node);
+  const rosidl_service_type_support_t * get_ts = ROSIDL_GET_SRV_TYPE_SUPPORT(
+    rcl_interfaces, srv,
+    GetParameters);
+  ret &= rclc_parameter_server_init_service(
+    &parameter_server->get_service, node, "/get_parameters",
+    get_ts);
+
+  const rosidl_service_type_support_t * get_types_ts = ROSIDL_GET_SRV_TYPE_SUPPORT(
+    rcl_interfaces,
+    srv,
+    GetParameterTypes);
+  ret &= rclc_parameter_server_init_service(
+    &parameter_server->get_types_service, node,
+    "/get_parameter_types", get_types_ts);
+
+  const rosidl_service_type_support_t * set_ts = ROSIDL_GET_SRV_TYPE_SUPPORT(
+    rcl_interfaces, srv,
+    SetParameters);
+  ret &= rclc_parameter_server_init_service(
+    &parameter_server->set_service, node, "/set_parameters",
+    set_ts);
+
+  const rosidl_service_type_support_t * list_ts = ROSIDL_GET_SRV_TYPE_SUPPORT(
+    rcl_interfaces, srv,
+    ListParameters);
+  ret &= rclc_parameter_server_init_service(
+    &parameter_server->list_service, node,
+    "/list_parameters", list_ts);
+
+  const rosidl_service_type_support_t * describe_ts = ROSIDL_GET_SRV_TYPE_SUPPORT(
+    rcl_interfaces, srv,
+    DescribeParameters);
+  ret &= rclc_parameter_server_init_service(
+    &parameter_server->describe_service, node,
+    "/describe_parameters", describe_ts);
+
+  parameter_server->notify_changed_over_dds = options->notify_changed_over_dds;
+  parameter_server->allow_undeclared_parameters = options->allow_undeclared_parameters;
+  parameter_server->low_mem_mode = options->low_mem_mode;
 
   if (parameter_server->notify_changed_over_dds) {
-    ret &= rcl_publisher_fini(&parameter_server->event_publisher, node);
+    const rosidl_message_type_support_t * event_ts = ROSIDL_GET_MSG_TYPE_SUPPORT(
+      rcl_interfaces,
+      msg,
+      ParameterEvent);
+    ret &= rclc_publisher_init(
+      &parameter_server->event_publisher, node, event_ts,
+      "/parameter_events",
+      &rmw_qos_profile_parameter_events);
   }
 
-  rosidl_runtime_c__String__fini(&parameter_server->event_list.node);
+  if (parameter_server->low_mem_mode) {
+    ret = init_parameter_server_memory_low_memory(parameter_server, node, options);
+  } else {
+    ret = init_parameter_server_memory(parameter_server, node, options);
+  }
 
+  return ret;
+}
+
+void
+rclc_parameter_server_fini_memory_low_memory(
+  rclc_parameter_server_t * parameter_server)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+
+  // Get request
+  allocator.deallocate(parameter_server->get_request.names.data[0].data, allocator.state);
+  allocator.deallocate(parameter_server->get_request.names.data, allocator.state);
+  parameter_server->get_request.names.capacity = 0;
+  parameter_server->get_request.names.size = 0;
+
+  // Get response
+  allocator.deallocate(parameter_server->get_response.values.data, allocator.state);
+  parameter_server->get_response.values.capacity = 0;
+  parameter_server->get_response.values.size = 0;
+
+  // Set request
+  allocator.deallocate(parameter_server->set_request.parameters.data[0].name.data, allocator.state);
+  allocator.deallocate(parameter_server->set_request.parameters.data, allocator.state);
+  parameter_server->set_request.parameters.capacity = 0;
+  parameter_server->set_request.parameters.size = 0;
+
+  // Set response
+  allocator.deallocate(parameter_server->set_response.results.data[0].reason.data, allocator.state);
+  allocator.deallocate(parameter_server->set_response.results.data, allocator.state);
+  parameter_server->set_response.results.capacity = 0;
+  parameter_server->set_response.results.size = 0;
+
+  // List response
+  for (size_t i = 0; i < parameter_server->list_response.result.names.capacity; i++) {
+    parameter_server->list_response.result.names.data[i].data = NULL;
+    parameter_server->list_response.result.names.data[i].capacity = 0;
+    parameter_server->list_response.result.names.data[i].size = 0;
+  }
+  allocator.deallocate(parameter_server->list_response.result.names.data, allocator.state);
+
+  // Get types request
+  allocator.deallocate(parameter_server->get_types_request.names.data[0].data, allocator.state);
+  allocator.deallocate(parameter_server->get_types_request.names.data, allocator.state);
+  parameter_server->get_types_request.names.capacity = 0;
+  parameter_server->get_types_request.names.size = 0;
+
+  // Get types response
+  allocator.deallocate(parameter_server->get_types_response.types.data, allocator.state);
+  parameter_server->get_types_response.types.capacity = 0;
+  parameter_server->get_types_response.types.size = 0;
+
+  // Describe parameters request
+  allocator.deallocate(parameter_server->describe_request.names.data[0].data, allocator.state);
+  allocator.deallocate(parameter_server->describe_request.names.data, allocator.state);
+  parameter_server->describe_request.names.size = 0;
+  parameter_server->describe_request.names.capacity = 0;
+
+  // Describe parameters response
+  allocator.deallocate(
+    parameter_server->describe_response.descriptors.data[0].floating_point_range.data,
+    allocator.state);
+  allocator.deallocate(
+    parameter_server->describe_response.descriptors.data[0].integer_range.data,
+    allocator.state);
+  allocator.deallocate(
+    parameter_server->describe_response.descriptors.data[0].description.data,
+    allocator.state);
+  allocator.deallocate(
+    parameter_server->describe_response.descriptors.data[0].additional_constraints.data,
+    allocator.state);
+  allocator.deallocate(parameter_server->describe_response.descriptors.data, allocator.state);
+  parameter_server->describe_response.descriptors.size = 0;
+  parameter_server->describe_response.descriptors.capacity = 0;
+
+  // Parameter list and parameter descriptors
+  for (size_t i = 0; i < parameter_server->parameter_list.capacity; i++) {
+    allocator.deallocate(parameter_server->parameter_list.data[i].name.data, allocator.state);
+    allocator.deallocate(
+      parameter_server->parameter_descriptors.data[i].floating_point_range.data,
+      allocator.state);
+    allocator.deallocate(
+      parameter_server->parameter_descriptors.data[i].integer_range.data,
+      allocator.state);
+  }
+
+  allocator.deallocate(parameter_server->parameter_list.data, allocator.state);
+  parameter_server->parameter_list.capacity = 0;
+  parameter_server->parameter_list.size = 0;
+
+  allocator.deallocate(parameter_server->parameter_descriptors.data, allocator.state);
+  parameter_server->parameter_descriptors.size = 0;
+  parameter_server->parameter_descriptors.capacity = 0;
+
+
+  if (parameter_server->notify_changed_over_dds) {
+    parameter_server->event_list.node.data = NULL;
+    parameter_server->event_list.node.capacity = 0;
+    parameter_server->event_list.node.size = 0;
+  }
+}
+
+void
+rclc_parameter_server_fini_memory(
+  rclc_parameter_server_t * parameter_server)
+{
   // Fini describe msgs
   for (size_t i = 0; i < parameter_server->describe_request.names.capacity; i++) {
     rosidl_runtime_c__String__fini(&parameter_server->describe_request.names.data[i]);
@@ -625,9 +985,41 @@ rclc_parameter_server_fini(
       &parameter_server->parameter_descriptors.data[i].floating_point_range);
   }
 
+  if (parameter_server->notify_changed_over_dds) {
+    rosidl_runtime_c__String__fini(&parameter_server->event_list.node);
+  }
+
   rcl_interfaces__msg__ParameterDescriptor__Sequence__fini(
     &parameter_server->parameter_descriptors);
+}
 
+rcl_ret_t
+rclc_parameter_server_fini(
+  rclc_parameter_server_t * parameter_server,
+  rcl_node_t * node)
+{
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    parameter_server, "parameter is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    node, "node is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+
+  rcl_ret_t ret = RCL_RET_OK;
+
+  ret &= rcl_service_fini(&parameter_server->list_service, node);
+  ret &= rcl_service_fini(&parameter_server->set_service, node);
+  ret &= rcl_service_fini(&parameter_server->get_service, node);
+  ret &= rcl_service_fini(&parameter_server->get_types_service, node);
+  ret &= rcl_service_fini(&parameter_server->describe_service, node);
+
+  if (parameter_server->notify_changed_over_dds) {
+    ret &= rcl_publisher_fini(&parameter_server->event_publisher, node);
+  }
+
+  if (parameter_server->low_mem_mode) {
+    rclc_parameter_server_fini_memory_low_memory(parameter_server);
+  } else {
+    rclc_parameter_server_fini_memory(parameter_server);
+  }
   return ret;
 }
 
@@ -707,7 +1099,7 @@ rclc_add_parameter(
   parameter_server->parameter_list.size++;
 
   // Add to parameter descriptors
-  if (!rclc_parameter_set_string(
+  if (!parameter_server->low_mem_mode && !rclc_parameter_set_string(
       &parameter_server->parameter_descriptors.data[index].name,
       parameter_name))
   {
@@ -746,8 +1138,8 @@ rclc_add_parameter_undeclared(
   }
 
   if (RCL_RET_OK != rclc_parameter_copy(
-    &parameter_server->parameter_list.data[index],
-    parameter))
+      &parameter_server->parameter_list.data[index],
+      parameter))
   {
     return RCL_RET_ERROR;
   }
@@ -755,7 +1147,7 @@ rclc_add_parameter_undeclared(
   parameter_server->parameter_list.size++;
 
   // Add to parameter descriptors
-  if (!rclc_parameter_set_string(
+  if (!parameter_server->low_mem_mode && !rclc_parameter_set_string(
       &parameter_server->parameter_descriptors.data[index].name,
       parameter->name.data))
   {
@@ -793,6 +1185,7 @@ rclc_delete_parameter(
     return RCL_RET_ERROR;
   }
 
+
   Parameter * param = &parameter_server->parameter_list.data[index];
   ParameterDescriptor * param_description = &parameter_server->parameter_descriptors.data[index];
 
@@ -801,11 +1194,13 @@ rclc_delete_parameter(
   param->value.type = RCLC_PARAMETER_NOT_SET;
 
   // Reset parameter description
-  rclc_parameter_set_string(&param_description->description, "");
-  rclc_parameter_set_string(&param_description->additional_constraints, "");
   param_description->type = RCLC_PARAMETER_NOT_SET;
   param_description->floating_point_range.size = 0;
   param_description->integer_range.size = 0;
+  if (!parameter_server->low_mem_mode) {
+    rclc_parameter_set_string(&param_description->description, "");
+    rclc_parameter_set_string(&param_description->additional_constraints, "");
+  }
 
   for (size_t i = index; i < (parameter_server->parameter_list.size - 1); i++) {
     // Move parameter list
@@ -816,7 +1211,8 @@ rclc_delete_parameter(
     // Move descriptors
     rclc_parameter_descriptor_copy(
       &parameter_server->parameter_descriptors.data[i],
-      &parameter_server->parameter_descriptors.data[i + 1]);
+      &parameter_server->parameter_descriptors.data[i + 1],
+      parameter_server->low_mem_mode);
   }
 
   parameter_server->parameter_descriptors.size--;
@@ -1098,8 +1494,12 @@ rclc_parameter_server_init_service(
 rcl_ret_t rclc_add_parameter_description(
   rclc_parameter_server_t * parameter_server,
   const char * parameter_name, const char * parameter_description,
-  bool read_only)
+  const char * additional_constraints)
 {
+  if (parameter_server->low_mem_mode) {
+    return UNSUPORTED_ON_LOW_MEM;
+  }
+
   size_t index = rclc_parameter_search_index(&parameter_server->parameter_list, parameter_name);
 
   if (index >= parameter_server->parameter_list.size) {
@@ -1113,14 +1513,38 @@ rcl_ret_t rclc_add_parameter_description(
     return RCL_RET_ERROR;
   }
 
+  // Set constrain description
+  if (!rclc_parameter_set_string(
+      &parameter_descriptor->additional_constraints,
+      additional_constraints))
+  {
+    return RCL_RET_ERROR;
+  }
+
+  return RCL_RET_OK;
+}
+
+rcl_ret_t rclc_set_parameter_read_only(
+  rclc_parameter_server_t * parameter_server,
+  const char * parameter_name, bool read_only)
+{
+  size_t index = rclc_parameter_search_index(&parameter_server->parameter_list, parameter_name);
+
+  if (index >= parameter_server->parameter_list.size) {
+    return RCL_RET_ERROR;
+  }
+
+  ParameterDescriptor * parameter_descriptor = &parameter_server->parameter_descriptors.data[index];
+
+  // Set flag
   parameter_descriptor->read_only = read_only;
+
   return RCL_RET_OK;
 }
 
 rcl_ret_t rclc_add_parameter_constraints_double(
   rclc_parameter_server_t * parameter_server,
-  const char * parameter_name,
-  const char * additional_constraints, double from_value,
+  const char * parameter_name, double from_value,
   double to_value, double step)
 {
   size_t index = rclc_parameter_search_index(&parameter_server->parameter_list, parameter_name);
@@ -1135,14 +1559,6 @@ rcl_ret_t rclc_add_parameter_constraints_double(
     return RCL_RET_ERROR;
   }
 
-  // Set constrain description
-  if (!rclc_parameter_set_string(
-      &parameter_descriptor->additional_constraints,
-      additional_constraints))
-  {
-    return RCL_RET_ERROR;
-  }
-
   parameter_descriptor->floating_point_range.data->from_value = from_value;
   parameter_descriptor->floating_point_range.data->to_value = to_value;
   parameter_descriptor->floating_point_range.data->step = step;
@@ -1153,8 +1569,7 @@ rcl_ret_t rclc_add_parameter_constraints_double(
 
 rcl_ret_t rclc_add_parameter_constraints_integer(
   rclc_parameter_server_t * parameter_server,
-  const char * parameter_name,
-  const char * additional_constraints, int64_t from_value,
+  const char * parameter_name, int64_t from_value,
   int64_t to_value, uint64_t step)
 {
   size_t index = rclc_parameter_search_index(&parameter_server->parameter_list, parameter_name);
@@ -1166,14 +1581,6 @@ rcl_ret_t rclc_add_parameter_constraints_integer(
   ParameterDescriptor * parameter_descriptor = &parameter_server->parameter_descriptors.data[index];
 
   if (parameter_descriptor->type != RCLC_PARAMETER_INT) {
-    return RCL_RET_ERROR;
-  }
-
-  // Set constrain description
-  if (!rclc_parameter_set_string(
-      &parameter_descriptor->additional_constraints,
-      additional_constraints))
-  {
     return RCL_RET_ERROR;
   }
 

--- a/rclc_parameter/src/rclc_parameter/parameter_server.c
+++ b/rclc_parameter/src/rclc_parameter/parameter_server.c
@@ -44,7 +44,8 @@ rcl_ret_t rclc_add_parameter_undeclared(
 
 rcl_ret_t rclc_parameter_execute_callback(
   rclc_parameter_server_t * parameter_server,
-  const Parameter * old_param, const Parameter * new_param);
+  const Parameter * old_param,
+  const Parameter * new_param);
 
 void
 rclc_parameter_server_describe_service_callback(
@@ -724,7 +725,8 @@ bool init_parameter_server_memory_low_memory(
 
   parameter_server->describe_response.descriptors.data[0].floating_point_range.data =
     allocator.zero_allocate(
-    1, sizeof(rcl_interfaces__msg__FloatingPointRange__Sequence),
+    1,
+    sizeof(rcl_interfaces__msg__FloatingPointRange__Sequence),
     allocator.state);
   parameter_server->describe_response.descriptors.data[0].floating_point_range.capacity = 1;
   parameter_server->describe_response.descriptors.data[0].floating_point_range.size = 0;
@@ -772,7 +774,8 @@ rclc_parameter_server_init_with_option(
   rcl_ret_t ret = RCL_RET_OK;
 
   const rosidl_service_type_support_t * get_ts = ROSIDL_GET_SRV_TYPE_SUPPORT(
-    rcl_interfaces, srv,
+    rcl_interfaces,
+    srv,
     GetParameters);
   ret &= rclc_parameter_server_init_service(
     &parameter_server->get_service, node, "/get_parameters",
@@ -787,21 +790,24 @@ rclc_parameter_server_init_with_option(
     "/get_parameter_types", get_types_ts);
 
   const rosidl_service_type_support_t * set_ts = ROSIDL_GET_SRV_TYPE_SUPPORT(
-    rcl_interfaces, srv,
+    rcl_interfaces,
+    srv,
     SetParameters);
   ret &= rclc_parameter_server_init_service(
     &parameter_server->set_service, node, "/set_parameters",
     set_ts);
 
   const rosidl_service_type_support_t * list_ts = ROSIDL_GET_SRV_TYPE_SUPPORT(
-    rcl_interfaces, srv,
+    rcl_interfaces,
+    srv,
     ListParameters);
   ret &= rclc_parameter_server_init_service(
     &parameter_server->list_service, node,
     "/list_parameters", list_ts);
 
   const rosidl_service_type_support_t * describe_ts = ROSIDL_GET_SRV_TYPE_SUPPORT(
-    rcl_interfaces, srv,
+    rcl_interfaces,
+    srv,
     DescribeParameters);
   ret &= rclc_parameter_server_init_service(
     &parameter_server->describe_service, node,
@@ -1039,7 +1045,7 @@ rclc_parameter_server_fini(
   rcl_node_t * node)
 {
   RCL_CHECK_FOR_NULL_WITH_MSG(
-    parameter_server, "parameter is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+    parameter_server, "parameter server is a null pointer", return RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_FOR_NULL_WITH_MSG(
     node, "node is a null pointer", return RCL_RET_INVALID_ARGUMENT);
 
@@ -1547,7 +1553,8 @@ rclc_parameter_server_init_service(
 
 rcl_ret_t rclc_add_parameter_description(
   rclc_parameter_server_t * parameter_server,
-  const char * parameter_name, const char * parameter_description,
+  const char * parameter_name,
+  const char * parameter_description,
   const char * additional_constraints)
 {
   if (parameter_server->low_mem_mode) {
@@ -1567,7 +1574,7 @@ rcl_ret_t rclc_add_parameter_description(
     return RCL_RET_ERROR;
   }
 
-  // Set constrain description
+  // Set constraint description
   if (!rclc_parameter_set_string(
       &parameter_descriptor->additional_constraints,
       additional_constraints))
@@ -1580,7 +1587,8 @@ rcl_ret_t rclc_add_parameter_description(
 
 rcl_ret_t rclc_set_parameter_read_only(
   rclc_parameter_server_t * parameter_server,
-  const char * parameter_name, bool read_only)
+  const char * parameter_name,
+  bool read_only)
 {
   if (parameter_server->on_callback) {
     return RCLC_PARAMETER_DISABLED_ON_CALLBACK;
@@ -1602,8 +1610,10 @@ rcl_ret_t rclc_set_parameter_read_only(
 
 rcl_ret_t rclc_add_parameter_constraint_double(
   rclc_parameter_server_t * parameter_server,
-  const char * parameter_name, double from_value,
-  double to_value, double step)
+  const char * parameter_name,
+  double from_value,
+  double to_value,
+  double step)
 {
   if (parameter_server->on_callback) {
     return RCLC_PARAMETER_DISABLED_ON_CALLBACK;
@@ -1660,7 +1670,8 @@ rcl_ret_t rclc_add_parameter_constraint_integer(
 
 rcl_ret_t rclc_parameter_execute_callback(
   rclc_parameter_server_t * parameter_server,
-  const Parameter * old_param, const Parameter * new_param)
+  const Parameter * old_param,
+  const Parameter * new_param)
 {
   bool ret = true;
 

--- a/rclc_parameter/src/rclc_parameter/parameter_server.c
+++ b/rclc_parameter/src/rclc_parameter/parameter_server.c
@@ -256,9 +256,9 @@ rclc_parameter_server_set_service_callback(
 
       if (ret == RCL_RET_INVALID_ARGUMENT) {
         rclc_parameter_set_string(message, "Set parameter error");
-      } else if (ret == PARAMETER_MODIFICATION_REJECTED) {
+      } else if (ret == RCLC_PARAMETER_MODIFICATION_REJECTED) {
         rclc_parameter_set_string(message, "Rejected by server");
-      } else if (ret == PARAMETER_TYPE_MISMATCH) {
+      } else if (ret == RCLC_PARAMETER_TYPE_MISMATCH) {
         rclc_parameter_set_string(message, "Type mismatch");
       } else {
         response->results.data[i].successful = true;
@@ -1067,7 +1067,19 @@ rcl_ret_t
 rclc_executor_add_parameter_server(
   rclc_executor_t * executor,
   rclc_parameter_server_t * parameter_server,
-  ModifiedParameter_Callback on_modification)
+  rclc_parameter_callback_t on_modification)
+{
+  return rclc_executor_add_parameter_server_with_context(
+    executor, parameter_server,
+    on_modification, NULL);
+}
+
+rcl_ret_t
+rclc_executor_add_parameter_server_with_context(
+  rclc_executor_t * executor,
+  rclc_parameter_server_t * parameter_server,
+  rclc_parameter_callback_t on_modification,
+  void * context)
 {
   RCL_CHECK_FOR_NULL_WITH_MSG(
     executor, "executor is a null pointer", return RCL_RET_INVALID_ARGUMENT);
@@ -1077,6 +1089,7 @@ rclc_executor_add_parameter_server(
   rcl_ret_t ret;
 
   parameter_server->on_modification = on_modification;
+  parameter_server->context = context;
 
   ret = rclc_executor_add_service_with_context(
     executor, &parameter_server->list_service,
@@ -1121,7 +1134,7 @@ rclc_add_parameter(
     parameter_name, "parameter_name is a null pointer", return RCL_RET_INVALID_ARGUMENT);
 
   if (parameter_server->on_callback) {
-    return DISABLE_ON_CALLBACK;
+    return RCLC_PARAMETER_DISABLED_ON_CALLBACK;
   }
 
   size_t index = parameter_server->parameter_list.size;
@@ -1223,7 +1236,7 @@ rclc_delete_parameter(
     parameter_name, "parameter_name is a null pointer", return RCL_RET_INVALID_ARGUMENT);
 
   if (parameter_server->on_callback) {
-    return DISABLE_ON_CALLBACK;
+    return RCLC_PARAMETER_DISABLED_ON_CALLBACK;
   }
 
   // Find parameter
@@ -1286,7 +1299,7 @@ rclc_parameter_set_bool(
     parameter_name, "parameter_name is a null pointer", return RCL_RET_INVALID_ARGUMENT);
 
   if (parameter_server->on_callback) {
-    return DISABLE_ON_CALLBACK;
+    return RCLC_PARAMETER_DISABLED_ON_CALLBACK;
   }
 
   Parameter * parameter =
@@ -1297,18 +1310,16 @@ rclc_parameter_set_bool(
   }
 
   if (parameter->value.type != RCLC_PARAMETER_BOOL) {
-    return PARAMETER_TYPE_MISMATCH;
+    return RCLC_PARAMETER_TYPE_MISMATCH;
   }
 
-  if (parameter_server->on_modification) {
-    Parameter new_parameter = *parameter;
-    new_parameter.value.bool_value = value;
+  Parameter new_parameter = *parameter;
+  new_parameter.value.bool_value = value;
 
-    if (RCL_RET_OK !=
-      rclc_parameter_execute_callback(parameter_server, parameter, &new_parameter))
-    {
-      return PARAMETER_MODIFICATION_REJECTED;
-    }
+  if (RCL_RET_OK !=
+    rclc_parameter_execute_callback(parameter_server, parameter, &new_parameter))
+  {
+    return RCLC_PARAMETER_MODIFICATION_REJECTED;
   }
 
   if (parameter_server->notify_changed_over_dds) {
@@ -1333,7 +1344,7 @@ rclc_parameter_set_int(
     parameter_name, "parameter_name is a null pointer", return RCL_RET_INVALID_ARGUMENT);
 
   if (parameter_server->on_callback) {
-    return DISABLE_ON_CALLBACK;
+    return RCLC_PARAMETER_DISABLED_ON_CALLBACK;
   }
 
   Parameter * parameter =
@@ -1344,18 +1355,16 @@ rclc_parameter_set_int(
   }
 
   if (parameter->value.type != RCLC_PARAMETER_INT) {
-    return PARAMETER_TYPE_MISMATCH;
+    return RCLC_PARAMETER_TYPE_MISMATCH;
   }
 
-  if (parameter_server->on_modification) {
-    Parameter new_parameter = *parameter;
-    new_parameter.value.integer_value = value;
+  Parameter new_parameter = *parameter;
+  new_parameter.value.integer_value = value;
 
-    if (RCL_RET_OK !=
-      rclc_parameter_execute_callback(parameter_server, parameter, &new_parameter))
-    {
-      return PARAMETER_MODIFICATION_REJECTED;
-    }
+  if (RCL_RET_OK !=
+    rclc_parameter_execute_callback(parameter_server, parameter, &new_parameter))
+  {
+    return RCLC_PARAMETER_MODIFICATION_REJECTED;
   }
 
   if (parameter_server->notify_changed_over_dds) {
@@ -1380,7 +1389,7 @@ rclc_parameter_set_double(
     parameter_name, "parameter_name is a null pointer", return RCL_RET_INVALID_ARGUMENT);
 
   if (parameter_server->on_callback) {
-    return DISABLE_ON_CALLBACK;
+    return RCLC_PARAMETER_DISABLED_ON_CALLBACK;
   }
 
   Parameter * parameter =
@@ -1391,18 +1400,16 @@ rclc_parameter_set_double(
   }
 
   if (parameter->value.type != RCLC_PARAMETER_DOUBLE) {
-    return PARAMETER_TYPE_MISMATCH;
+    return RCLC_PARAMETER_TYPE_MISMATCH;
   }
 
-  if (parameter_server->on_modification) {
-    Parameter new_parameter = *parameter;
-    new_parameter.value.double_value = value;
+  Parameter new_parameter = *parameter;
+  new_parameter.value.double_value = value;
 
-    if (RCL_RET_OK !=
-      rclc_parameter_execute_callback(parameter_server, parameter, &new_parameter))
-    {
-      return PARAMETER_MODIFICATION_REJECTED;
-    }
+  if (RCL_RET_OK !=
+    rclc_parameter_execute_callback(parameter_server, parameter, &new_parameter))
+  {
+    return RCLC_PARAMETER_MODIFICATION_REJECTED;
   }
 
   if (parameter_server->notify_changed_over_dds) {
@@ -1544,7 +1551,7 @@ rcl_ret_t rclc_add_parameter_description(
   const char * additional_constraints)
 {
   if (parameter_server->low_mem_mode) {
-    return UNSUPORTED_ON_LOW_MEM;
+    return RCLC_PARAMETER_UNSUPORTED_ON_LOW_MEM;
   }
 
   size_t index = rclc_parameter_search_index(&parameter_server->parameter_list, parameter_name);
@@ -1576,7 +1583,7 @@ rcl_ret_t rclc_set_parameter_read_only(
   const char * parameter_name, bool read_only)
 {
   if (parameter_server->on_callback) {
-    return DISABLE_ON_CALLBACK;
+    return RCLC_PARAMETER_DISABLED_ON_CALLBACK;
   }
 
   size_t index = rclc_parameter_search_index(&parameter_server->parameter_list, parameter_name);
@@ -1599,7 +1606,7 @@ rcl_ret_t rclc_add_parameter_constraints_double(
   double to_value, double step)
 {
   if (parameter_server->on_callback) {
-    return DISABLE_ON_CALLBACK;
+    return RCLC_PARAMETER_DISABLED_ON_CALLBACK;
   }
 
   size_t index = rclc_parameter_search_index(&parameter_server->parameter_list, parameter_name);
@@ -1628,7 +1635,7 @@ rcl_ret_t rclc_add_parameter_constraints_integer(
   int64_t to_value, uint64_t step)
 {
   if (parameter_server->on_callback) {
-    return DISABLE_ON_CALLBACK;
+    return RCLC_PARAMETER_DISABLED_ON_CALLBACK;
   }
 
   size_t index = rclc_parameter_search_index(&parameter_server->parameter_list, parameter_name);
@@ -1659,11 +1666,11 @@ rcl_ret_t rclc_parameter_execute_callback(
 
   if (parameter_server->on_modification) {
     parameter_server->on_callback = true;
-    ret = parameter_server->on_modification(old_param, new_param);
+    ret = parameter_server->on_modification(old_param, new_param, parameter_server->context);
     parameter_server->on_callback = false;
   }
 
-  return ret ? RCL_RET_OK : PARAMETER_MODIFICATION_REJECTED;
+  return ret ? RCL_RET_OK : RCLC_PARAMETER_MODIFICATION_REJECTED;
 }
 
 #if __cplusplus

--- a/rclc_parameter/src/rclc_parameter/parameter_server.c
+++ b/rclc_parameter/src/rclc_parameter/parameter_server.c
@@ -63,7 +63,7 @@ rclc_parameter_server_describe_service_callback(
 
   response->descriptors.size = request->names.size;
 
-  for (size_t i = 0; i < request->names.size; i++) {
+  for (size_t i = 0; i < request->names.size; ++i) {
     size_t index = rclc_parameter_search_index(
       &param_server->parameter_list,
       request->names.data[i].data);
@@ -109,7 +109,7 @@ rclc_parameter_server_list_service_callback(
 
   response->result.names.size = param_server->parameter_list.size;
 
-  for (size_t i = 0; i < response->result.names.size; i++) {
+  for (size_t i = 0; i < response->result.names.size; ++i) {
     if (!param_server->low_mem_mode) {
       rclc_parameter_set_string(
         &response->result.names.data[i],
@@ -141,7 +141,7 @@ rclc_parameter_server_get_service_callback(
 
   response->values.size = size;
 
-  for (size_t i = 0; i < size; i++) {
+  for (size_t i = 0; i < size; ++i) {
     Parameter * parameter = rclc_parameter_search(
       &param_server->parameter_list,
       request->names.data[i].data);
@@ -171,7 +171,7 @@ rclc_parameter_server_get_types_service_callback(
 
   response->types.size = request->names.size;
 
-  for (size_t i = 0; i < response->types.size; i++) {
+  for (size_t i = 0; i < response->types.size; ++i) {
     Parameter * parameter = rclc_parameter_search(
       &param_server->parameter_list,
       request->names.data[i].data);
@@ -201,7 +201,7 @@ rclc_parameter_server_set_service_callback(
 
   response->results.size = request->parameters.size;
 
-  for (size_t i = 0; i < response->results.size; i++) {
+  for (size_t i = 0; i < response->results.size; ++i) {
     rosidl_runtime_c__String * message =
       (rosidl_runtime_c__String *) &response->results.data[i].reason;
     size_t index = rclc_parameter_search_index(
@@ -338,7 +338,7 @@ init_parameter_server_memory(
   parameter_server->parameter_list.size = 0;
 
   // Pre-init strings
-  for (size_t i = 0; i < options->max_params; i++) {
+  for (size_t i = 0; i < options->max_params; ++i) {
     mem_allocs_ok &= rosidl_runtime_c__String__assignn(
       &parameter_server->parameter_list.data[i].name,
       (const char *) empty_string,
@@ -357,7 +357,7 @@ init_parameter_server_memory(
   parameter_server->list_response.result.names.size = 0;
 
   // Pre-init strings
-  for (size_t i = 0; i < options->max_params; i++) {
+  for (size_t i = 0; i < options->max_params; ++i) {
     mem_allocs_ok &= rosidl_runtime_c__String__assignn(
       &parameter_server->list_response.result.names.data[i],
       (const char *) empty_string,
@@ -379,7 +379,7 @@ init_parameter_server_memory(
   parameter_server->get_response.values.size = 0;
 
   // Pre-init strings
-  for (size_t i = 0; i < options->max_params; i++) {
+  for (size_t i = 0; i < options->max_params; ++i) {
     mem_allocs_ok &= rosidl_runtime_c__String__assignn(
       &parameter_server->get_request.names.data[i],
       (const char *) empty_string,
@@ -404,7 +404,7 @@ init_parameter_server_memory(
   size_t string_reason_capacity = RCLC_SET_ERROR_MAX_STRING_LENGTH - 1;
 
   // Pre-init strings
-  for (size_t i = 0; i < options->max_params; i++) {
+  for (size_t i = 0; i < options->max_params; ++i) {
     mem_allocs_ok &= rosidl_runtime_c__String__assignn(
       &parameter_server->set_request.parameters.data[i].name,
       (const char *) empty_string,
@@ -432,7 +432,7 @@ init_parameter_server_memory(
     options->max_params);
   parameter_server->get_types_response.types.size = 0;
 
-  for (size_t i = 0; i < options->max_params; i++) {
+  for (size_t i = 0; i < options->max_params; ++i) {
     mem_allocs_ok &= rosidl_runtime_c__String__assignn(
       &parameter_server->get_types_request.names.data[i],
       (const char *) empty_string,
@@ -460,7 +460,7 @@ init_parameter_server_memory(
     options->max_params);
   parameter_server->parameter_descriptors.size = 0;
 
-  for (size_t i = 0; i < options->max_params; i++) {
+  for (size_t i = 0; i < options->max_params; ++i) {
     // Init describe_request members
     mem_allocs_ok &= rosidl_runtime_c__String__assignn(
       &parameter_server->describe_request.names.data[i],
@@ -557,7 +557,7 @@ bool init_parameter_server_memory_low_memory(
   parameter_server->parameter_descriptors.size = 0;
   parameter_server->parameter_descriptors.capacity = options->max_params;
 
-  for (size_t i = 0; i < options->max_params; i++) {
+  for (size_t i = 0; i < options->max_params; ++i) {
     parameter_server->parameter_list.data[i].name.data = allocator.allocate(
       sizeof(char) * RCLC_PARAMETER_MAX_STRING_LENGTH, allocator.state);
     parameter_server->parameter_list.data[i].name.data[0] = '\0';
@@ -612,7 +612,7 @@ bool init_parameter_server_memory_low_memory(
     allocator.allocate(sizeof(rosidl_runtime_c__String) * options->max_params, allocator.state);
   parameter_server->list_response.result.names.size = 0;
   parameter_server->list_response.result.names.capacity = options->max_params;
-  for (size_t i = 0; i < options->max_params; i++) {
+  for (size_t i = 0; i < options->max_params; ++i) {
     parameter_server->list_response.result.names.data[i].data =
       parameter_server->parameter_list.data[i].name.data;
     parameter_server->list_response.result.names.data[i].capacity =
@@ -865,7 +865,7 @@ rclc_parameter_server_fini_memory_low_memory(
   parameter_server->set_response.results.size = 0;
 
   // List response
-  for (size_t i = 0; i < parameter_server->list_response.result.names.capacity; i++) {
+  for (size_t i = 0; i < parameter_server->list_response.result.names.capacity; ++i) {
     parameter_server->list_response.result.names.data[i].data = NULL;
     parameter_server->list_response.result.names.data[i].capacity = 0;
     parameter_server->list_response.result.names.data[i].size = 0;
@@ -907,7 +907,7 @@ rclc_parameter_server_fini_memory_low_memory(
   parameter_server->describe_response.descriptors.capacity = 0;
 
   // Parameter list and parameter descriptors
-  for (size_t i = 0; i < parameter_server->parameter_list.capacity; i++) {
+  for (size_t i = 0; i < parameter_server->parameter_list.capacity; ++i) {
     allocator.deallocate(parameter_server->parameter_list.data[i].name.data, allocator.state);
     allocator.deallocate(
       parameter_server->parameter_list.data[i].value.string_value.data,
@@ -946,7 +946,7 @@ rclc_parameter_server_fini_memory(
   rclc_parameter_server_t * parameter_server)
 {
   // Fini describe msgs
-  for (size_t i = 0; i < parameter_server->describe_request.names.capacity; i++) {
+  for (size_t i = 0; i < parameter_server->describe_request.names.capacity; ++i) {
     rosidl_runtime_c__String__fini(&parameter_server->describe_request.names.data[i]);
     rosidl_runtime_c__String__fini(&parameter_server->describe_response.descriptors.data[i].name);
     rosidl_runtime_c__String__fini(
@@ -966,7 +966,7 @@ rclc_parameter_server_fini_memory(
   rcl_interfaces__srv__DescribeParameters_Request__fini(&parameter_server->describe_request);
 
   // Fini get types msgs
-  for (size_t i = 0; i < parameter_server->get_types_request.names.capacity; i++) {
+  for (size_t i = 0; i < parameter_server->get_types_request.names.capacity; ++i) {
     rosidl_runtime_c__String__fini(&parameter_server->get_types_request.names.data[i]);
   }
 
@@ -976,7 +976,7 @@ rclc_parameter_server_fini_memory(
   rcl_interfaces__srv__GetParameterTypes_Request__fini(&parameter_server->get_types_request);
 
   // Finish set msgs
-  for (size_t i = 0; i < parameter_server->set_request.parameters.capacity; i++) {
+  for (size_t i = 0; i < parameter_server->set_request.parameters.capacity; ++i) {
     rosidl_runtime_c__String__fini(&parameter_server->set_request.parameters.data[i].name);
     rosidl_runtime_c__String__fini(&parameter_server->set_response.results.data[i].reason);
   }
@@ -987,7 +987,7 @@ rclc_parameter_server_fini_memory(
   rcl_interfaces__srv__SetParameters_Request__fini(&parameter_server->set_request);
 
   // Finish get msgs
-  for (size_t i = 0; i < parameter_server->get_request.names.capacity; i++) {
+  for (size_t i = 0; i < parameter_server->get_request.names.capacity; ++i) {
     rosidl_runtime_c__String__fini(&parameter_server->get_request.names.data[i]);
   }
 
@@ -997,7 +997,7 @@ rclc_parameter_server_fini_memory(
   rcl_interfaces__srv__GetParameters_Request__fini(&parameter_server->get_request);
 
   // Finish list msgs
-  for (size_t i = 0; i < parameter_server->list_response.result.names.capacity; i++) {
+  for (size_t i = 0; i < parameter_server->list_response.result.names.capacity; ++i) {
     rosidl_runtime_c__String__fini(&parameter_server->list_response.result.names.data[i]);
   }
 
@@ -1006,14 +1006,14 @@ rclc_parameter_server_fini_memory(
   rcl_interfaces__srv__ListParameters_Request__fini(&parameter_server->list_request);
 
   // Free parameter list
-  for (size_t i = 0; i < parameter_server->parameter_list.capacity; i++) {
+  for (size_t i = 0; i < parameter_server->parameter_list.capacity; ++i) {
     rosidl_runtime_c__String__fini(&parameter_server->parameter_list.data[i].name);
   }
 
   rcl_interfaces__msg__Parameter__Sequence__fini(&parameter_server->parameter_list);
 
   // Free parameter descriptor list
-  for (size_t i = 0; i < parameter_server->parameter_descriptors.capacity; i++) {
+  for (size_t i = 0; i < parameter_server->parameter_descriptors.capacity; ++i) {
     rosidl_runtime_c__String__fini(&parameter_server->parameter_descriptors.data[i].name);
     rosidl_runtime_c__String__fini(&parameter_server->parameter_descriptors.data[i].description);
     rosidl_runtime_c__String__fini(
@@ -1153,7 +1153,7 @@ rclc_add_parameter(
   }
 
   parameter_server->parameter_list.data[index].value.type = type;
-  parameter_server->parameter_list.size++;
+  ++parameter_server->parameter_list.size;
 
   // Add to parameter descriptors
   if (!parameter_server->low_mem_mode && !rclc_parameter_set_string(
@@ -1164,7 +1164,7 @@ rclc_add_parameter(
   }
 
   parameter_server->parameter_descriptors.data[index].type = type;
-  parameter_server->parameter_descriptors.size++;
+  ++parameter_server->parameter_descriptors.size;
 
   if (parameter_server->notify_changed_over_dds) {
     rclc_parameter_prepare_new_event(
@@ -1201,7 +1201,7 @@ rclc_add_parameter_undeclared(
     return RCL_RET_ERROR;
   }
 
-  parameter_server->parameter_list.size++;
+  ++parameter_server->parameter_list.size;
 
   // Add to parameter descriptors
   if (!parameter_server->low_mem_mode && !rclc_parameter_set_string(
@@ -1213,7 +1213,7 @@ rclc_add_parameter_undeclared(
 
   parameter_server->parameter_descriptors.data[index].type =
     parameter->value.type;
-  parameter_server->parameter_descriptors.size++;
+  ++parameter_server->parameter_descriptors.size;
 
   if (parameter_server->notify_changed_over_dds) {
     rclc_parameter_prepare_new_event(
@@ -1268,7 +1268,7 @@ rclc_delete_parameter(
     rclc_parameter_set_string(&param_description->additional_constraints, "");
   }
 
-  for (size_t i = index; i < (parameter_server->parameter_list.size - 1); i++) {
+  for (size_t i = index; i < (parameter_server->parameter_list.size - 1); ++i) {
     // Move parameter list
     rclc_parameter_copy(
       &parameter_server->parameter_list.data[i],
@@ -1600,7 +1600,7 @@ rcl_ret_t rclc_set_parameter_read_only(
   return RCL_RET_OK;
 }
 
-rcl_ret_t rclc_add_parameter_constraints_double(
+rcl_ret_t rclc_add_parameter_constraint_double(
   rclc_parameter_server_t * parameter_server,
   const char * parameter_name, double from_value,
   double to_value, double step)
@@ -1629,7 +1629,7 @@ rcl_ret_t rclc_add_parameter_constraints_double(
   return RCL_RET_OK;
 }
 
-rcl_ret_t rclc_add_parameter_constraints_integer(
+rcl_ret_t rclc_add_parameter_constraint_integer(
   rclc_parameter_server_t * parameter_server,
   const char * parameter_name, int64_t from_value,
   int64_t to_value, uint64_t step)

--- a/rclc_parameter/src/rclc_parameter/parameter_server.c
+++ b/rclc_parameter/src/rclc_parameter/parameter_server.c
@@ -998,8 +998,7 @@ rclc_parameter_server_fini_memory(
     rosidl_runtime_c__String__fini(
       &parameter_server->parameter_descriptors.data[i].additional_constraints);
     rcl_interfaces__msg__IntegerRange__Sequence__fini(
-      &parameter_server->parameter_descriptors.data[
-        i].integer_range);
+      &parameter_server->parameter_descriptors.data[i].integer_range);
     rcl_interfaces__msg__FloatingPointRange__Sequence__fini(
       &parameter_server->parameter_descriptors.data[i].floating_point_range);
   }

--- a/rclc_parameter/src/rclc_parameter/parameter_server.c
+++ b/rclc_parameter/src/rclc_parameter/parameter_server.c
@@ -21,8 +21,12 @@ extern "C"
 
 #include <rcutils/time.h>
 #include <rclc_parameter/rclc_parameter.h>
+#include <rcl_interfaces/msg/floating_point_range.h>
+#include <rcl_interfaces/msg/integer_range.h>
 
 #include "./parameter_utils.h"
+
+#define RCLC_SET_ERROR_MAX_STRING_LENGTH 25
 
 rcl_ret_t
 rclc_parameter_server_init_service(
@@ -34,6 +38,10 @@ rclc_parameter_server_init_service(
 rcl_ret_t rclc_parameter_service_publish_event(
   rclc_parameter_server_t * parameter_server);
 
+rcl_ret_t rclc_add_parameter_undeclared(
+  rclc_parameter_server_t * parameter_server,
+  Parameter * parameter);
+
 void
 rclc_parameter_server_describe_service_callback(
   const void * req,
@@ -44,24 +52,24 @@ rclc_parameter_server_describe_service_callback(
   DescribeParameters_Request * request = (DescribeParameters_Request *) req;
   DescribeParameters_Response * response = (DescribeParameters_Response *) res;
 
-  size_t size = (request->names.size > param_server->parameter_list.size) ?
-    param_server->parameter_list.size :
-    request->names.size;
+  // Clean previous response msg
+  memset(
+    &response->descriptors.data[0], 0,
+    sizeof(response->descriptors.data[0]) * response->descriptors.capacity);
+  response->descriptors.size = request->names.size;
 
-  response->descriptors.size = size;
-
-  for (size_t i = 0; i < size; i++) {
-    rclc_parameter_set_string(
-      &response->descriptors.data[i].name,
-      request->names.data[i].data);
-
-    Parameter * parameter = rclc_parameter_search(
+  for (size_t i = 0; i < request->names.size; i++) {
+    size_t index = rclc_parameter_search_index(
       &param_server->parameter_list,
       request->names.data[i].data);
 
-    response->descriptors.data[i].type = (parameter != NULL) ?
-      parameter->value.type :
-      RCLC_PARAMETER_NOT_SET;
+    if (index < param_server->parameter_descriptors.size) {
+      response->descriptors.data[i] = param_server->parameter_descriptors.data[index];
+      response->descriptors.data[i].name = param_server->parameter_list.data[index].name;
+    } else {
+      response->descriptors.data[i].name = request->names.data[i];
+      response->descriptors.data[i].type = RCLC_PARAMETER_NOT_SET;
+    }
   }
 }
 
@@ -79,9 +87,7 @@ rclc_parameter_server_list_service_callback(
   response->result.names.size = param_server->parameter_list.size;
 
   for (size_t i = 0; i < response->result.names.size; i++) {
-    rclc_parameter_set_string(
-      &response->result.names.data[i],
-      param_server->parameter_list.data[i].name.data);
+    response->result.names.data[i] = param_server->parameter_list.data[i].name;
   }
 }
 
@@ -99,6 +105,10 @@ rclc_parameter_server_get_service_callback(
     param_server->parameter_list.size :
     request->names.size;
 
+  // Clean previous response msg
+  memset(
+    &response->values.data[0], 0,
+    sizeof(response->values.data[0]) * response->values.capacity);
   response->values.size = size;
 
   for (size_t i = 0; i < size; i++) {
@@ -129,6 +139,8 @@ rclc_parameter_server_get_types_service_callback(
     return;
   }
 
+  // Clean previous response msg
+  memset(&response->types.data[0], 0, sizeof(response->types.data[0]) * response->types.capacity);
   response->types.size = request->names.size;
 
   for (size_t i = 0; i < response->types.size; i++) {
@@ -169,62 +181,86 @@ rclc_parameter_server_set_service_callback(
       request->parameters.data[i].name.data);
     rcl_ret_t ret = RCL_RET_OK;
 
+    // Clean previous response msg
+    response->results.data[i].successful = false;
     rclc_parameter_set_string(message, "");
 
     if (parameter != NULL) {
-      response->results.data[i].successful = true;
-
-      if (parameter->value.type != request->parameters.data[i].value.type) {
-        rclc_parameter_set_string(message, "Type mismatch");
-        response->results.data[i].successful = false;
-        continue;
-      }
-
       switch (request->parameters.data[i].value.type) {
         case RCLC_PARAMETER_NOT_SET:
-          rclc_parameter_set_string(message, "Type not set");
-          response->results.data[i].successful = false;
+          if (param_server->on_modification && !param_server->on_modification(parameter, NULL)) {
+            ret = PARAMETER_MODIFICATION_REJECTED;
+          } else {
+            ret = rclc_delete_parameter(param_server, parameter->name.data);
+          }
           break;
 
         case RCLC_PARAMETER_BOOL:
           ret =
             rclc_parameter_set_bool(
-            parameter_server, parameter->name.data,
+            param_server, parameter->name.data,
             request->parameters.data[i].value.bool_value);
           break;
         case RCLC_PARAMETER_INT:
           ret =
             rclc_parameter_set_int(
-            parameter_server, parameter->name.data,
+            param_server, parameter->name.data,
             request->parameters.data[i].value.integer_value);
           break;
         case RCLC_PARAMETER_DOUBLE:
           ret =
             rclc_parameter_set_double(
-            parameter_server, parameter->name.data,
+            param_server, parameter->name.data,
             request->parameters.data[i].value.double_value);
           break;
 
         default:
           rclc_parameter_set_string(message, "Type not supported");
-          response->results.data[i].successful = false;
           break;
       }
 
       if (ret == RCL_RET_INVALID_ARGUMENT) {
         rclc_parameter_set_string(message, "Set parameter error");
-        response->results.data[i].successful = false;
+      } else if (ret == PARAMETER_MODIFICATION_REJECTED) {
+        rclc_parameter_set_string(message, "Rejected by server");
+      } else if (ret == PARAMETER_TYPE_MISMATCH) {
+        rclc_parameter_set_string(message, "Type mismatch");
+      } else {
+        response->results.data[i].successful = true;
+      }
+    } else if (param_server->allow_undeclared_parameters && // NOLINT
+      request->parameters.data[i].value.type != RCLC_PARAMETER_NOT_SET)
+    {
+      size_t remaining_capacity = param_server->parameter_list.capacity -
+        param_server->parameter_list.size;
+
+      if (0 == remaining_capacity) {
+        // Check parameter server capacity
+        rclc_parameter_set_string(message, "Parameter server is full");
+      } else if (param_server->on_modification && // NOLINT
+        !param_server->on_modification(NULL, &request->parameters.data[i]))
+      {
+        // Check server callback
+        rclc_parameter_set_string(message, "New parameter rejected");
+      } else if (RCL_RET_OK != // NOLINT
+        rclc_add_parameter_undeclared(param_server, &request->parameters.data[i]))
+      {
+        // Check add parameter
+        rclc_parameter_set_string(message, "Add parameter failed");
+      } else {
+        rclc_parameter_set_string(message, "New parameter added");
+        response->results.data[i].successful = true;
       }
     } else {
       rclc_parameter_set_string(message, "Parameter not found");
-      response->results.data[i].successful = false;
     }
   }
 }
 
 const rclc_parameter_options_t DEFAULT_PARAMETER_SERVER_OPTIONS = {
   .notify_changed_over_dds = true,
-  .max_params = 4
+  .max_params = 4,
+  .allow_undeclared_parameters = false,
 };
 
 rcl_ret_t rclc_parameter_server_init_default(
@@ -292,6 +328,8 @@ rclc_parameter_server_init_with_option(
     "/describe_parameters", describe_ts);
 
   parameter_server->notify_changed_over_dds = options->notify_changed_over_dds;
+  parameter_server->allow_undeclared_parameters = options->allow_undeclared_parameters;
+
   if (parameter_server->notify_changed_over_dds) {
     const rosidl_message_type_support_t * event_ts = ROSIDL_GET_MSG_TYPE_SUPPORT(
       rcl_interfaces,
@@ -303,7 +341,7 @@ rclc_parameter_server_init_with_option(
       &rmw_qos_profile_parameter_events);
   }
 
-  static char empty_string[RCLC_PARAMETER_MAX_STRING_LENGTH];
+  char empty_string[RCLC_PARAMETER_MAX_STRING_LENGTH];
   memset(empty_string, ' ', RCLC_PARAMETER_MAX_STRING_LENGTH);
   empty_string[RCLC_PARAMETER_MAX_STRING_LENGTH - 1] = '\0';
 
@@ -320,6 +358,7 @@ rclc_parameter_server_init_with_option(
       (const char *) empty_string);
   }
 
+  // Init list service msgs
   mem_allocs_ok &=
     rcl_interfaces__srv__ListParameters_Request__init(&parameter_server->list_request);
   mem_allocs_ok &= rcl_interfaces__srv__ListParameters_Response__init(
@@ -329,13 +368,7 @@ rclc_parameter_server_init_with_option(
     options->max_params);
   parameter_server->list_response.result.names.size = 0;
 
-  // Pre-init strings
-  for (size_t i = 0; i < options->max_params; i++) {
-    mem_allocs_ok &= rosidl_runtime_c__String__assign(
-      &parameter_server->list_response.result.names.data[i],
-      (const char *) empty_string);
-  }
-
+  // Init Get service msgs
   mem_allocs_ok &= rcl_interfaces__srv__GetParameters_Request__init(&parameter_server->get_request);
   mem_allocs_ok &=
     rcl_interfaces__srv__GetParameters_Response__init(&parameter_server->get_response);
@@ -355,6 +388,7 @@ rclc_parameter_server_init_with_option(
       (const char *) empty_string);
   }
 
+  // Init Set service msgs
   mem_allocs_ok &= rcl_interfaces__srv__SetParameters_Request__init(&parameter_server->set_request);
   mem_allocs_ok &=
     rcl_interfaces__srv__SetParameters_Response__init(&parameter_server->set_response);
@@ -367,16 +401,22 @@ rclc_parameter_server_init_with_option(
     options->max_params);
   parameter_server->set_response.results.size = 0;
 
+  char reason_empty_string[RCLC_SET_ERROR_MAX_STRING_LENGTH];
+  memset(reason_empty_string, ' ', RCLC_SET_ERROR_MAX_STRING_LENGTH);
+  reason_empty_string[RCLC_SET_ERROR_MAX_STRING_LENGTH - 1] = '\0';
+
   // Pre-init strings
   for (size_t i = 0; i < options->max_params; i++) {
     mem_allocs_ok &= rosidl_runtime_c__String__assign(
       &parameter_server->set_request.parameters.data[i].name,
       (const char *) empty_string);
+
     mem_allocs_ok &= rosidl_runtime_c__String__assign(
       &parameter_server->set_response.results.data[i].reason,
-      (const char *) empty_string);
+      (const char *) reason_empty_string);
   }
 
+  // Init Get types service msgs
   mem_allocs_ok &= rcl_interfaces__srv__GetParameterTypes_Request__init(
     &parameter_server->get_types_request);
   mem_allocs_ok &= rcl_interfaces__srv__GetParameterTypes_Response__init(
@@ -396,6 +436,7 @@ rclc_parameter_server_init_with_option(
       (const char *) empty_string);
   }
 
+  // Init Describe service msgs
   mem_allocs_ok &= rcl_interfaces__srv__DescribeParameters_Request__init(
     &parameter_server->describe_request);
   mem_allocs_ok &= rcl_interfaces__srv__DescribeParameters_Response__init(
@@ -404,24 +445,44 @@ rclc_parameter_server_init_with_option(
     &parameter_server->describe_request.names,
     options->max_params);
   parameter_server->describe_request.names.size = 0;
+
   mem_allocs_ok &= rcl_interfaces__msg__ParameterDescriptor__Sequence__init(
     &parameter_server->describe_response.descriptors,
     options->max_params);
   parameter_server->describe_response.descriptors.size = 0;
+
+  mem_allocs_ok &= rcl_interfaces__msg__ParameterDescriptor__Sequence__init(
+    &parameter_server->parameter_descriptors,
+    options->max_params);
+  parameter_server->parameter_descriptors.size = 0;
 
   for (size_t i = 0; i < options->max_params; i++) {
     mem_allocs_ok &= rosidl_runtime_c__String__assign(
       &parameter_server->describe_request.names.data[i],
       (const char *) empty_string);
     mem_allocs_ok &= rosidl_runtime_c__String__assign(
-      &parameter_server->describe_response.descriptors.data[i].name,
+      &parameter_server->parameter_descriptors.data[i].description,
       (const char *) empty_string);
+    mem_allocs_ok &= rosidl_runtime_c__String__assign(
+      &parameter_server->parameter_descriptors.data[i].additional_constraints,
+      (const char *) empty_string);
+    mem_allocs_ok &= rcl_interfaces__msg__FloatingPointRange__Sequence__init(
+      &parameter_server->parameter_descriptors.data[i].floating_point_range,
+      rcl_interfaces__msg__ParameterDescriptor__floating_point_range__MAX_SIZE);
+    parameter_server->parameter_descriptors.data[i].floating_point_range.size = 0;
+    mem_allocs_ok &= rcl_interfaces__msg__IntegerRange__Sequence__init(
+      &parameter_server->parameter_descriptors.data[i].integer_range,
+      rcl_interfaces__msg__ParameterDescriptor__integer_range__MAX_SIZE);
+    parameter_server->parameter_descriptors.data[i].integer_range.size = 0;
   }
 
-  mem_allocs_ok &= rcl_interfaces__msg__ParameterEvent__init(&parameter_server->event_list);
-  mem_allocs_ok &= rosidl_runtime_c__String__assign(
-    &parameter_server->event_list.node,
-    rcl_node_get_name(node));
+  // Init event publisher msgs
+  if (parameter_server->notify_changed_over_dds) {
+    mem_allocs_ok &= rcl_interfaces__msg__ParameterEvent__init(&parameter_server->event_list);
+    mem_allocs_ok &= rosidl_runtime_c__String__assign(
+      &parameter_server->event_list.node,
+      rcl_node_get_name(node));
+  }
 
   if (!mem_allocs_ok) {
     ret = RCL_RET_ERROR;
@@ -449,14 +510,12 @@ rclc_parameter_server_fini(
   ret |= rcl_service_fini(&parameter_server->describe_service, node);
 
   if (parameter_server->notify_changed_over_dds) {
-    ret |= rcl_publisher_fini(&parameter_server->event_publisher, node);
+    ret &= rcl_publisher_fini(&parameter_server->event_publisher, node);
+    rosidl_runtime_c__String__fini(&parameter_server->event_list.node);
   }
-
-  rosidl_runtime_c__String__fini(&parameter_server->event_list.node);
 
   for (size_t i = 0; i < parameter_server->describe_request.names.capacity; i++) {
     rosidl_runtime_c__String__fini(&parameter_server->describe_request.names.data[i]);
-    rosidl_runtime_c__String__fini(&parameter_server->describe_response.descriptors.data[i].name);
   }
 
   rcl_interfaces__msg__ParameterDescriptor__Sequence__fini(
@@ -493,19 +552,31 @@ rclc_parameter_server_fini(
   rcl_interfaces__srv__GetParameters_Response__fini(&parameter_server->get_response);
   rcl_interfaces__srv__GetParameters_Request__fini(&parameter_server->get_request);
 
-  for (size_t i = 0; i < parameter_server->list_response.result.names.capacity; i++) {
-    rosidl_runtime_c__String__fini(&parameter_server->list_response.result.names.data[i]);
-  }
-
   rosidl_runtime_c__String__Sequence__fini(&parameter_server->list_response.result.names);
   rcl_interfaces__srv__ListParameters_Response__fini(&parameter_server->list_response);
   rcl_interfaces__srv__ListParameters_Request__fini(&parameter_server->list_request);
 
+  // Free parameter list
   for (size_t i = 0; i < parameter_server->parameter_list.capacity; i++) {
     rosidl_runtime_c__String__fini(&parameter_server->parameter_list.data[i].name);
   }
 
   rcl_interfaces__msg__Parameter__Sequence__fini(&parameter_server->parameter_list);
+
+  // Free parameter descriptor list
+  for (size_t i = 0; i < parameter_server->parameter_descriptors.capacity; i++) {
+    rosidl_runtime_c__String__fini(&parameter_server->parameter_descriptors.data[i].description);
+    rosidl_runtime_c__String__fini(
+      &parameter_server->parameter_descriptors.data[i].additional_constraints);
+    rcl_interfaces__msg__IntegerRange__Sequence__fini(
+      &parameter_server->parameter_descriptors.data[
+        i].integer_range);
+    rcl_interfaces__msg__FloatingPointRange__Sequence__fini(
+      &parameter_server->parameter_descriptors.data[i].floating_point_range);
+  }
+
+  rcl_interfaces__msg__ParameterDescriptor__Sequence__fini(
+    &parameter_server->parameter_descriptors);
 
   return ret;
 }
@@ -585,13 +656,108 @@ rclc_add_parameter(
   parameter_server->parameter_list.data[index].value.type = type;
   parameter_server->parameter_list.size++;
 
+  // Add to parameter descriptors
+  parameter_server->parameter_descriptors.data[index].type = type;
+  parameter_server->parameter_descriptors.size++;
+
   if (parameter_server->notify_changed_over_dds) {
-    rclc_parameter_prepare_parameter_event(
+    rclc_parameter_prepare_new_event(
       &parameter_server->event_list,
-      &parameter_server->parameter_list.data[index],
-      true);
+      &parameter_server->parameter_list.data[index]);
     return rclc_parameter_service_publish_event(parameter_server);
   }
+
+  return RCL_RET_OK;
+}
+
+rcl_ret_t
+rclc_add_parameter_undeclared(
+  rclc_parameter_server_t * parameter_server,
+  Parameter * parameter)
+{
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    parameter_server, "parameter_server is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    parameter, "parameter is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+
+  size_t index = parameter_server->parameter_list.size;
+
+  if (index >= parameter_server->parameter_list.capacity ||
+    rclc_parameter_search(&parameter_server->parameter_list, parameter->name.data) != NULL)
+  {
+    return RCL_RET_ERROR;
+  }
+
+  if (!rclc_parameter_set_string(
+      &parameter_server->parameter_list.data[index].name,
+      parameter->name.data))
+  {
+    return RCL_RET_ERROR;
+  }
+
+  parameter_server->parameter_list.data[index].value = parameter->value;
+  parameter_server->parameter_list.size++;
+
+  // Add to parameter descriptors
+  parameter_server->parameter_descriptors.data[index].type =
+    parameter_server->parameter_list.data[index].value.type;
+  parameter_server->parameter_descriptors.size++;
+
+  if (parameter_server->notify_changed_over_dds) {
+    rclc_parameter_prepare_new_event(
+      &parameter_server->event_list,
+      &parameter_server->parameter_list.data[index]);
+    return rclc_parameter_service_publish_event(parameter_server);
+  }
+
+  return RCL_RET_OK;
+}
+
+rcl_ret_t
+rclc_delete_parameter(
+  rclc_parameter_server_t * parameter_server,
+  const char * parameter_name)
+{
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    parameter_server, "parameter_server is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    parameter_name, "parameter_name is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+
+  // Find parameter
+  size_t index = rclc_parameter_search_index(&parameter_server->parameter_list, parameter_name);
+
+  if (index >= parameter_server->parameter_list.size) {
+    return RCL_RET_ERROR;
+  }
+
+  Parameter * param = &parameter_server->parameter_list.data[index];
+  ParameterDescriptor * param_description = &parameter_server->parameter_descriptors.data[index];
+
+  // Reset parameter
+  rclc_parameter_set_string(&param->name, "");
+  param->value.type = RCLC_PARAMETER_NOT_SET;
+
+  // Reset parameter description
+  rclc_parameter_set_string(&param_description->description, "");
+  rclc_parameter_set_string(&param_description->additional_constraints, "");
+  param_description->type = RCLC_PARAMETER_NOT_SET;
+  // TODO(acuadros95): Reset floating_point_range and integer_range;
+
+  // Move parameters and fix size TODO: Check this
+  for (size_t i = index; i < parameter_server->parameter_list.size; i++) {
+    // Move parameter list
+    rclc_parameter_copy(
+      &parameter_server->parameter_list.data[i],
+      &parameter_server->parameter_list.data[i + 1]);
+
+    // Move descriptors
+    memcpy(
+      &parameter_server->parameter_descriptors.data[i],
+      &parameter_server->parameter_descriptors.data[i + 1], sizeof(ParameterDescriptor));
+  }
+
+  parameter_server->parameter_descriptors.size--;
+  parameter_server->parameter_list.size--;
 
   return RCL_RET_OK;
 }
@@ -615,19 +781,32 @@ rclc_parameter_set_bool(
   }
 
   if (parameter->value.type != RCLC_PARAMETER_BOOL) {
-    return RCL_RET_INVALID_ARGUMENT;
-  }
-
-  parameter->value.bool_value = value;
-
-  if (parameter_server->notify_changed_over_dds) {
-    rclc_parameter_prepare_parameter_event(&parameter_server->event_list, parameter, false);
-    rclc_parameter_service_publish_event(parameter_server);
+    return PARAMETER_TYPE_MISMATCH;
   }
 
   if (parameter_server->on_modification) {
-    parameter_server->on_modification(parameter);
+    // Avoid recursive loop if called within on_modification_cb
+    ModifiedParameter_Callback on_modification_cb = parameter_server->on_modification;
+    parameter_server->on_modification = NULL;
+
+    Parameter new_parameter = *parameter;
+    new_parameter.value.bool_value = value;
+
+    bool user_ret = on_modification_cb(parameter, &new_parameter);
+
+    parameter_server->on_modification = on_modification_cb;
+
+    if (!user_ret) {
+      return PARAMETER_MODIFICATION_REJECTED;
+    }
   }
+
+  if (parameter_server->notify_changed_over_dds) {
+    rclc_parameter_prepare_changed_event(&parameter_server->event_list, parameter);
+    rclc_parameter_service_publish_event(parameter_server);
+  }
+
+  parameter->value.bool_value = value;
 
   return RCL_RET_OK;
 }
@@ -651,19 +830,32 @@ rclc_parameter_set_int(
   }
 
   if (parameter->value.type != RCLC_PARAMETER_INT) {
-    return RCL_RET_INVALID_ARGUMENT;
-  }
-
-  parameter->value.integer_value = value;
-
-  if (parameter_server->notify_changed_over_dds) {
-    rclc_parameter_prepare_parameter_event(&parameter_server->event_list, parameter, false);
-    rclc_parameter_service_publish_event(parameter_server);
+    return PARAMETER_TYPE_MISMATCH;
   }
 
   if (parameter_server->on_modification) {
-    parameter_server->on_modification(parameter);
+    // Avoid recursive loop if called within on_modification_cb
+    ModifiedParameter_Callback on_modification_cb = parameter_server->on_modification;
+    parameter_server->on_modification = NULL;
+
+    Parameter new_parameter = *parameter;
+    new_parameter.value.integer_value = value;
+
+    bool user_ret = on_modification_cb(parameter, &new_parameter);
+
+    parameter_server->on_modification = on_modification_cb;
+
+    if (!user_ret) {
+      return PARAMETER_MODIFICATION_REJECTED;
+    }
   }
+
+  if (parameter_server->notify_changed_over_dds) {
+    rclc_parameter_prepare_changed_event(&parameter_server->event_list, parameter);
+    rclc_parameter_service_publish_event(parameter_server);
+  }
+
+  parameter->value.integer_value = value;
 
   return RCL_RET_OK;
 }
@@ -687,19 +879,32 @@ rclc_parameter_set_double(
   }
 
   if (parameter->value.type != RCLC_PARAMETER_DOUBLE) {
-    return RCL_RET_INVALID_ARGUMENT;
-  }
-
-  parameter->value.double_value = value;
-
-  if (parameter_server->notify_changed_over_dds) {
-    rclc_parameter_prepare_parameter_event(&parameter_server->event_list, parameter, false);
-    rclc_parameter_service_publish_event(parameter_server);
+    return PARAMETER_TYPE_MISMATCH;
   }
 
   if (parameter_server->on_modification) {
-    parameter_server->on_modification(parameter);
+    // Avoid recursive loop if called within on_modification_cb
+    ModifiedParameter_Callback on_modification_cb = parameter_server->on_modification;
+    parameter_server->on_modification = NULL;
+
+    Parameter new_parameter = *parameter;
+    new_parameter.value.double_value = value;
+
+    bool user_ret = on_modification_cb(parameter, &new_parameter);
+
+    parameter_server->on_modification = on_modification_cb;
+
+    if (!user_ret) {
+      return PARAMETER_MODIFICATION_REJECTED;
+    }
   }
+
+  if (parameter_server->notify_changed_over_dds) {
+    rclc_parameter_prepare_changed_event(&parameter_server->event_list, parameter);
+    rclc_parameter_service_publish_event(parameter_server);
+  }
+
+  parameter->value.double_value = value;
 
   return RCL_RET_OK;
 }
@@ -825,6 +1030,96 @@ rclc_parameter_server_init_service(
   memcpy(get_service_name, node_name, strlen(node_name) + 1);
   memcpy((get_service_name + strlen(node_name)), service_name, strlen(service_name) + 1);
   return rclc_service_init(service, node, srv_type, get_service_name, &rmw_qos_profile_parameters);
+}
+
+rcl_ret_t rclc_add_parameter_description(
+  rclc_parameter_server_t * parameter_server,
+  const char * parameter_name, const char * parameter_description,
+  bool read_only)
+{
+  size_t index = rclc_parameter_search_index(&parameter_server->parameter_list, parameter_name);
+
+  if (index >= parameter_server->parameter_list.size) {
+    return RCL_RET_ERROR;
+  }
+
+  ParameterDescriptor * parameter_descriptor = &parameter_server->parameter_descriptors.data[index];
+
+  // Set parameter description
+  if (!rclc_parameter_set_string(&parameter_descriptor->description, parameter_description)) {
+    return RCL_RET_ERROR;
+  }
+
+  parameter_descriptor->read_only = read_only;
+  return RCL_RET_OK;
+}
+
+rcl_ret_t rclc_add_parameter_constraints_double(
+  rclc_parameter_server_t * parameter_server,
+  const char * parameter_name,
+  const char * additional_constraints, double from_value,
+  double to_value, double step)
+{
+  size_t index = rclc_parameter_search_index(&parameter_server->parameter_list, parameter_name);
+
+  if (index >= parameter_server->parameter_list.size) {
+    return RCL_RET_ERROR;
+  }
+
+  ParameterDescriptor * parameter_descriptor = &parameter_server->parameter_descriptors.data[index];
+
+  if (parameter_descriptor->type != RCLC_PARAMETER_DOUBLE) {
+    return RCL_RET_ERROR;
+  }
+
+  // Set constrain description
+  if (!rclc_parameter_set_string(
+      &parameter_descriptor->additional_constraints,
+      additional_constraints))
+  {
+    return RCL_RET_ERROR;
+  }
+
+  parameter_descriptor->floating_point_range.data->from_value = from_value;
+  parameter_descriptor->floating_point_range.data->to_value = to_value;
+  parameter_descriptor->floating_point_range.data->step = step;
+  parameter_descriptor->floating_point_range.size = 1;
+
+  return RCL_RET_OK;
+}
+
+rcl_ret_t rclc_add_parameter_constraints_integer(
+  rclc_parameter_server_t * parameter_server,
+  const char * parameter_name,
+  const char * additional_constraints, int64_t from_value,
+  int64_t to_value, uint64_t step)
+{
+  size_t index = rclc_parameter_search_index(&parameter_server->parameter_list, parameter_name);
+
+  if (index >= parameter_server->parameter_list.size) {
+    return RCL_RET_ERROR;
+  }
+
+  ParameterDescriptor * parameter_descriptor = &parameter_server->parameter_descriptors.data[index];
+
+  if (parameter_descriptor->type != RCLC_PARAMETER_INT) {
+    return RCL_RET_ERROR;
+  }
+
+  // Set constrain description
+  if (!rclc_parameter_set_string(
+      &parameter_descriptor->additional_constraints,
+      additional_constraints))
+  {
+    return RCL_RET_ERROR;
+  }
+
+  parameter_descriptor->integer_range.data->from_value = from_value;
+  parameter_descriptor->integer_range.data->to_value = to_value;
+  parameter_descriptor->integer_range.data->step = step;
+  parameter_descriptor->integer_range.size = 1;
+
+  return RCL_RET_OK;
 }
 
 #if __cplusplus

--- a/rclc_parameter/src/rclc_parameter/parameter_utils.c
+++ b/rclc_parameter/src/rclc_parameter/parameter_utils.c
@@ -216,6 +216,47 @@ rcl_ret_t rclc_parameter_reset_parameter_event(
   return RCL_RET_OK;
 }
 
+rcl_ret_t rclc_parameter_initialize_empty_string(
+  rosidl_runtime_c__String * str,
+  size_t capacity)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(str, RCL_RET_INVALID_ARGUMENT);
+
+  if (capacity < 1) {
+    return RCL_RET_INVALID_ARGUMENT;
+  }
+
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+
+  str->data = allocator.allocate(sizeof(char) * capacity, allocator.state);
+
+  if (str->data == NULL) {
+    return RCL_RET_ERROR;
+  }
+
+  str->data[0] = '\0';
+  str->capacity = capacity;
+  str->size = 0;
+
+  return RCL_RET_OK;
+}
+
+bool rclc_parameter_descriptor_initialize_string(rosidl_runtime_c__String * str)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(str, false);
+
+  static char empty_string[RCLC_PARAMETER_MAX_STRING_LENGTH] = "";
+  size_t string_capacity = RCLC_PARAMETER_MAX_STRING_LENGTH - 1;
+
+  bool ret = rosidl_runtime_c__String__assignn(
+    str,
+    (const char *) empty_string,
+    string_capacity);
+
+  str->size = 0;
+  return ret;
+}
+
 #if __cplusplus
 }
 #endif /* if __cplusplus */

--- a/rclc_parameter/src/rclc_parameter/parameter_utils.c
+++ b/rclc_parameter/src/rclc_parameter/parameter_utils.c
@@ -62,6 +62,42 @@ rclc_parameter_copy(
   return rclc_parameter_value_copy(&dst->value, &src->value);
 }
 
+rcl_ret_t
+rclc_parameter_descriptor_copy(
+  ParameterDescriptor * dst,
+  const ParameterDescriptor * src)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(dst, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(src, RCL_RET_INVALID_ARGUMENT);
+
+  if (!rclc_parameter_set_string(&dst->name, src->name.data)) {
+    return RCL_RET_ERROR;
+  }
+
+  if (!rclc_parameter_set_string(&dst->description, src->description.data)) {
+    return RCL_RET_ERROR;
+  }
+
+  if (!rclc_parameter_set_string(&dst->additional_constraints, src->additional_constraints.data)) {
+    return RCL_RET_ERROR;
+  }
+
+  dst->type = src->type;
+  dst->read_only = src->read_only;
+
+  dst->floating_point_range.data[0].from_value = src->floating_point_range.data[0].from_value;
+  dst->floating_point_range.data[0].to_value = src->floating_point_range.data[0].to_value;
+  dst->floating_point_range.data[0].step = src->floating_point_range.data[0].step;
+  dst->floating_point_range.size = src->floating_point_range.size;
+
+  dst->integer_range.data[0].from_value = src->integer_range.data[0].from_value;
+  dst->integer_range.data[0].to_value = src->integer_range.data[0].to_value;
+  dst->integer_range.data[0].step = src->integer_range.data[0].step;
+  dst->integer_range.size = src->integer_range.size;
+
+  return RCL_RET_OK;
+}
+
 Parameter *
 rclc_parameter_search(
   Parameter__Sequence * parameter_list,

--- a/rclc_parameter/src/rclc_parameter/parameter_utils.c
+++ b/rclc_parameter/src/rclc_parameter/parameter_utils.c
@@ -112,7 +112,7 @@ rclc_parameter_search(
   RCL_CHECK_ARGUMENT_FOR_NULL(parameter_list, NULL);
   RCL_CHECK_ARGUMENT_FOR_NULL(param_name, NULL);
 
-  for (size_t i = 0; i < parameter_list->size; i++) {
+  for (size_t i = 0; i < parameter_list->size; ++i) {
     if (!strcmp(param_name, parameter_list->data[i].name.data)) {
       return &parameter_list->data[i];
     }
@@ -130,7 +130,7 @@ rclc_parameter_search_index(
   RCL_CHECK_ARGUMENT_FOR_NULL(param_name, SIZE_MAX);
 
   size_t index = SIZE_MAX;
-  for (size_t i = 0; i < parameter_list->size; i++) {
+  for (size_t i = 0; i < parameter_list->size; ++i) {
     if (!strcmp(param_name, parameter_list->data[i].name.data)) {
       index = i;
       break;

--- a/rclc_parameter/src/rclc_parameter/parameter_utils.c
+++ b/rclc_parameter/src/rclc_parameter/parameter_utils.c
@@ -65,21 +65,27 @@ rclc_parameter_copy(
 rcl_ret_t
 rclc_parameter_descriptor_copy(
   ParameterDescriptor * dst,
-  const ParameterDescriptor * src)
+  const ParameterDescriptor * src,
+  bool low_mem)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(dst, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(src, RCL_RET_INVALID_ARGUMENT);
 
-  if (!rclc_parameter_set_string(&dst->name, src->name.data)) {
-    return RCL_RET_ERROR;
-  }
+  if (!low_mem) {
+    if (!rclc_parameter_set_string(&dst->name, src->name.data)) {
+      return RCL_RET_ERROR;
+    }
 
-  if (!rclc_parameter_set_string(&dst->description, src->description.data)) {
-    return RCL_RET_ERROR;
-  }
+    if (!rclc_parameter_set_string(&dst->description, src->description.data)) {
+      return RCL_RET_ERROR;
+    }
 
-  if (!rclc_parameter_set_string(&dst->additional_constraints, src->additional_constraints.data)) {
-    return RCL_RET_ERROR;
+    if (!rclc_parameter_set_string(
+        &dst->additional_constraints,
+        src->additional_constraints.data))
+    {
+      return RCL_RET_ERROR;
+    }
   }
 
   dst->type = src->type;

--- a/rclc_parameter/src/rclc_parameter/parameter_utils.h
+++ b/rclc_parameter/src/rclc_parameter/parameter_utils.h
@@ -39,7 +39,8 @@ rclc_parameter_copy(
 rcl_ret_t
 rclc_parameter_descriptor_copy(
   ParameterDescriptor * dst,
-  const ParameterDescriptor * src);
+  const ParameterDescriptor * src,
+  bool low_mem);
 
 Parameter *
 rclc_parameter_search(

--- a/rclc_parameter/src/rclc_parameter/parameter_utils.h
+++ b/rclc_parameter/src/rclc_parameter/parameter_utils.h
@@ -71,6 +71,13 @@ rcl_ret_t rclc_parameter_prepare_deleted_event(
 rcl_ret_t rclc_parameter_reset_parameter_event(
   ParameterEvent * event);
 
+rcl_ret_t rclc_parameter_initialize_empty_string(
+  rosidl_runtime_c__String * str,
+  size_t capacity);
+
+bool rclc_parameter_descriptor_initialize_string(
+  rosidl_runtime_c__String * str);
+
 #if __cplusplus
 }
 #endif  // if __cplusplus

--- a/rclc_parameter/src/rclc_parameter/parameter_utils.h
+++ b/rclc_parameter/src/rclc_parameter/parameter_utils.h
@@ -36,6 +36,11 @@ rclc_parameter_copy(
   Parameter * dst,
   const Parameter * src);
 
+rcl_ret_t
+rclc_parameter_descriptor_copy(
+  ParameterDescriptor * dst,
+  const ParameterDescriptor * src);
+
 Parameter *
 rclc_parameter_search(
   Parameter__Sequence * parameter_list,

--- a/rclc_parameter/src/rclc_parameter/parameter_utils.h
+++ b/rclc_parameter/src/rclc_parameter/parameter_utils.h
@@ -41,14 +41,29 @@ rclc_parameter_search(
   Parameter__Sequence * parameter_list,
   const char * param_name);
 
+size_t
+rclc_parameter_search_index(
+  Parameter__Sequence * parameter_list,
+  const char * param_name);
+
 bool rclc_parameter_set_string(
   rosidl_runtime_c__String * str,
   const char * value);
 
-void rclc_parameter_prepare_parameter_event(
+rcl_ret_t rclc_parameter_prepare_new_event(
   ParameterEvent * event,
-  Parameter * parameter,
-  bool new);
+  Parameter * parameter);
+
+rcl_ret_t rclc_parameter_prepare_changed_event(
+  ParameterEvent * event,
+  Parameter * parameter);
+
+rcl_ret_t rclc_parameter_prepare_deleted_event(
+  ParameterEvent * event,
+  Parameter * parameter);
+
+rcl_ret_t rclc_parameter_reset_parameter_event(
+  ParameterEvent * event);
 
 #if __cplusplus
 }

--- a/rclc_parameter/test/rclc_parameter/test_parameter.cpp
+++ b/rclc_parameter/test/rclc_parameter/test_parameter.cpp
@@ -22,11 +22,11 @@ extern "C"
 #include <rclc_parameter/rclc_parameter.h>
 }
 
-#include <rclcpp/rclcpp.hpp>
-
 #include <string>
 #include <memory>
 #include <vector>
+
+#include <rclcpp/rclcpp.hpp>
 
 #include "rclc_parameter/parameter_utils.h"
 

--- a/rclc_parameter/test/rclc_parameter/test_parameter.cpp
+++ b/rclc_parameter/test/rclc_parameter/test_parameter.cpp
@@ -186,7 +186,7 @@ public:
     void * context)
   {
     ParameterTestBase * obj = reinterpret_cast<ParameterTestBase *>(context);
-    obj->callback_calls++;
+    ++obj->callback_calls;
     return obj->on_parameter_changed(old_param, new_param);
   }
 
@@ -238,7 +238,7 @@ TEST_P(ParameterTestBase, rclc_set_get_parameter) {
 
     ASSERT_EQ(rclc_parameter_set_bool(&param_server, param_name, set_value), RCL_RET_OK);
     EXPECT_EQ(callback_calls, expected_callback_calls);
-    expected_callback_calls++;
+    ++expected_callback_calls;
 
     // Get new value
     ASSERT_EQ(rclc_parameter_get_bool(&param_server, param_name, &get_value), RCL_RET_OK);
@@ -267,7 +267,7 @@ TEST_P(ParameterTestBase, rclc_set_get_parameter) {
 
     ASSERT_EQ(rclc_parameter_set_int(&param_server, param_name, set_value), RCL_RET_OK);
     ASSERT_EQ(callback_calls, expected_callback_calls);
-    expected_callback_calls++;
+    ++expected_callback_calls;
 
     // Get new value
     ASSERT_EQ(rclc_parameter_get_int(&param_server, param_name, &get_value), RCL_RET_OK);
@@ -298,7 +298,7 @@ TEST_P(ParameterTestBase, rclc_set_get_parameter) {
       rclc_parameter_set_double(
         &param_server, param_name, set_value), RCL_RET_OK);
     ASSERT_EQ(callback_calls, expected_callback_calls);
-    expected_callback_calls++;
+    ++expected_callback_calls;
 
     // Get new value
     ASSERT_EQ(rclc_parameter_get_double(&param_server, param_name, &get_value), RCL_RET_OK);
@@ -368,7 +368,7 @@ TEST_P(ParameterTestBase, rclcpp_set_get_parameter) {
     ASSERT_TRUE(result[0].successful);
     ASSERT_EQ(result[0].reason, "");
     ASSERT_EQ(callback_calls, expected_callback_calls);
-    expected_callback_calls++;
+    ++expected_callback_calls;
 
     // Get new value
     get_value = parameters_client->get_parameter<bool>(param_name);
@@ -399,7 +399,7 @@ TEST_P(ParameterTestBase, rclcpp_set_get_parameter) {
 
     // Check callback values
     ASSERT_EQ(callback_calls, expected_callback_calls);
-    expected_callback_calls++;
+    ++expected_callback_calls;
 
     // Get new value
     get_value = parameters_client->get_parameter<int>(param_name);
@@ -430,7 +430,7 @@ TEST_P(ParameterTestBase, rclcpp_set_get_parameter) {
 
     // Check callback values
     ASSERT_EQ(callback_calls, expected_callback_calls);
-    expected_callback_calls++;
+    ++expected_callback_calls;
 
     // Get new value
     get_value = parameters_client->get_parameter<double>(param_name);
@@ -456,7 +456,7 @@ TEST_P(ParameterTestBase, rclcpp_set_get_parameter) {
     ASSERT_FALSE(result[0].successful);
     ASSERT_EQ(result[0].reason, "Rejected by server");
     ASSERT_EQ(callback_calls, expected_callback_calls);
-    expected_callback_calls++;
+    ++expected_callback_calls;
 
     // Get value
     double second_get_value = parameters_client->get_parameter<double>(param_name);
@@ -507,7 +507,7 @@ TEST_P(ParameterTestBase, rclcpp_delete_parameter) {
   ASSERT_FALSE(result[0].successful);
   ASSERT_EQ(result[0].reason, "Rejected by server");
   ASSERT_EQ(callback_calls, expected_callback_calls);
-  expected_callback_calls++;
+  ++expected_callback_calls;
 
   auto list_params = parameters_client->list_parameters({}, 4, default_spin_timeout);
   ASSERT_EQ(list_params.names.size(), 3u);
@@ -524,7 +524,7 @@ TEST_P(ParameterTestBase, rclcpp_delete_parameter) {
   ASSERT_TRUE(result[0].successful);
   ASSERT_EQ(result[0].reason, "");
   ASSERT_EQ(callback_calls, expected_callback_calls);
-  expected_callback_calls++;
+  ++expected_callback_calls;
 
   // Use auxiliar RCLCPP node for check
   list_params = parameters_client->list_parameters({}, 4, default_spin_timeout);
@@ -555,7 +555,7 @@ TEST_P(ParameterTestBase, rclcpp_add_parameter) {
     ASSERT_FALSE(result[0].successful);
     ASSERT_EQ(result[0].reason, "New parameter rejected");
     ASSERT_EQ(callback_calls, expected_callback_calls);
-    expected_callback_calls++;
+    ++expected_callback_calls;
 
     auto list_params = parameters_client->list_parameters({}, 4, default_spin_timeout);
     ASSERT_EQ(list_params.names.size(), 3u);
@@ -665,11 +665,11 @@ TEST_P(ParameterTestBase, rclcpp_parameter_description) {
       &param_server, "param2", parameter_description.c_str(),
       additional_constraints.c_str()), RCL_RET_OK);
   ASSERT_EQ(
-    rclc_add_parameter_constraints_integer(
+    rclc_add_parameter_constraint_integer(
       &param_server, "param2", int_from, int_to,
       int_step), RCL_RET_OK);
   ASSERT_EQ(
-    rclc_add_parameter_constraints_double(
+    rclc_add_parameter_constraint_double(
       &param_server, "param3", double_from, double_to,
       double_step), RCL_RET_OK);
 
@@ -722,11 +722,11 @@ TEST_P(ParameterTestBase, rclcpp_parameter_description_low) {
       &param_server, "param2", "",
       ""), RCLC_PARAMETER_UNSUPORTED_ON_LOW_MEM);
   ASSERT_EQ(
-    rclc_add_parameter_constraints_integer(
+    rclc_add_parameter_constraint_integer(
       &param_server, "param2", int_from, int_to,
       int_step), RCL_RET_OK);
   ASSERT_EQ(
-    rclc_add_parameter_constraints_double(
+    rclc_add_parameter_constraint_double(
       &param_server, "param3", double_from, double_to,
       double_step), RCL_RET_OK);
 

--- a/rclc_parameter/test/rclc_parameter/test_parameter.cpp
+++ b/rclc_parameter/test/rclc_parameter/test_parameter.cpp
@@ -18,242 +18,568 @@ extern "C"
 {
 #include <rclc/node.h>
 #include <rclc_parameter/rclc_parameter.h>
+#include "rclc_parameter/parameter_utils.h"
 }
+
+#include <rclcpp/rclcpp.hpp>
 
 #include <string>
 #include <memory>
 #include <vector>
 
-#include <rclcpp/rclcpp.hpp>
 
 using namespace std::chrono_literals;
 
-// #include "parameter_client.hpp"
-
-static int callcack_calls = 0;
-static rclc_parameter_type_t expected_type;
-static union {
-  bool bool_value;
-  int64_t integer_value;
-  double double_value;
-} expected_value;
-
-void on_parameter_changed(Parameter * param)
-{
-  callcack_calls++;
-  ASSERT_EQ(expected_type, param->value.type);
-  switch (param->value.type) {
-    case RCLC_PARAMETER_BOOL:
-      ASSERT_EQ(param->value.bool_value, expected_value.bool_value);
-      break;
-    case RCLC_PARAMETER_INT:
-      ASSERT_EQ(param->value.integer_value, expected_value.integer_value);
-      break;
-    case RCLC_PARAMETER_DOUBLE:
-      ASSERT_EQ(param->value.double_value, expected_value.double_value);
-      break;
-    default:
-      break;
-  }
-}
-
-TEST(Test, rclc_node_init_default) {
+TEST(ParameterTestUnitary, rclc_parameter_server_init_default) {
   std::string node_name("test_node");
 
-  // Create auxiliar RCLCPP node
-  rclcpp::init(0, NULL);
-  auto param_client_node = std::make_shared<rclcpp::Node>("param_aux_client");
-  auto parameters_client = std::make_shared<rclcpp::SyncParametersClient>(
-    param_client_node,
-    node_name);
-
   // Init RCLC support
-  rcl_ret_t rc;
   rclc_support_t support;
   rcl_allocator_t allocator = rcl_get_default_allocator();
-  rc = rclc_support_init(&support, 0, nullptr, &allocator);
-  EXPECT_EQ(RCL_RET_OK, rc);
+  ASSERT_EQ(rclc_support_init(&support, 0, nullptr, &allocator), RCL_RET_OK);
 
   // Init node
   rcl_node_t node;
-  rc = rclc_node_init_default(&node, node_name.c_str(), "", &support);
-  EXPECT_EQ(RCL_RET_OK, rc);
+  ASSERT_EQ(rclc_node_init_default(&node, node_name.c_str(), "", &support), RCL_RET_OK);
 
   // Init parameter server
   rclc_parameter_server_t param_server;
-  rc = rclc_parameter_server_init_default(&param_server, &node);
-  EXPECT_EQ(RCL_RET_OK, rc);
+  ASSERT_EQ(rclc_parameter_server_init_default(&param_server, &node), RCL_RET_OK);
 
   // Test with wrong arguments
-  rc = rclc_parameter_server_init_default(NULL, &node);
-  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rc);
+  ASSERT_EQ(rclc_parameter_server_init_default(NULL, &node), RCL_RET_INVALID_ARGUMENT);
+  rcutils_reset_error();
 
-  rc = rclc_parameter_server_init_default(&param_server, NULL);
-  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rc);
+  ASSERT_EQ(rclc_parameter_server_init_default(&param_server, NULL), RCL_RET_INVALID_ARGUMENT);
+  rcutils_reset_error();
 
   // Add parameter to executor
   rclc_executor_t executor;
   rclc_executor_init(
     &executor, &support.context, RCLC_PARAMETER_EXECUTOR_HANDLES_NUMBER,
     &allocator);
-  rc = rclc_executor_add_parameter_server(&executor, &param_server, on_parameter_changed);
-  EXPECT_EQ(RCL_RET_OK, rc);
+  ASSERT_EQ(rclc_executor_add_parameter_server(&executor, &param_server, nullptr), RCL_RET_OK);
+
+  // Destroy parameter server
+  ASSERT_EQ(rclc_parameter_server_fini(&param_server, &node), RCL_RET_OK);
+}
+
+TEST(ParameterTestUnitary, rclc_add_parameter) {
+  std::string node_name("test_node");
+
+  // Init RCLC support
+  rclc_support_t support;
+  rcl_allocator_t allocator = rcl_get_default_allocator();
+  ASSERT_EQ(rclc_support_init(&support, 0, nullptr, &allocator), RCL_RET_OK);
+  // Init node
+  rcl_node_t node;
+  ASSERT_EQ(rclc_node_init_default(&node, node_name.c_str(), "", &support), RCL_RET_OK);
+
+  // Init parameter server
+  rclc_parameter_server_t param_server;
+  ASSERT_EQ(rclc_parameter_server_init_default(&param_server, &node), RCL_RET_OK);
 
   // Test add parameter
   std::vector<std::string> param_names;
-  rc = rclc_add_parameter(&param_server, "param1", RCLC_PARAMETER_BOOL);
+  ASSERT_EQ(rclc_add_parameter(&param_server, "param1", RCLC_PARAMETER_BOOL), RCL_RET_OK);
   param_names.push_back("param1");
-  EXPECT_EQ(RCL_RET_OK, rc);
 
   // Fail on duplicated name
-  rc = rclc_add_parameter(&param_server, "param1", RCLC_PARAMETER_DOUBLE);
-  EXPECT_EQ(RCL_RET_ERROR, rc);
+  ASSERT_EQ(rclc_add_parameter(&param_server, "param1", RCLC_PARAMETER_DOUBLE), RCL_RET_ERROR);
 
   // Fail on name length
   char overflow_name[RCLC_PARAMETER_MAX_STRING_LENGTH + 1];
   memset(overflow_name, ' ', RCLC_PARAMETER_MAX_STRING_LENGTH + 1);
   overflow_name[RCLC_PARAMETER_MAX_STRING_LENGTH] = '\0';
 
-  rc = rclc_add_parameter(&param_server, overflow_name, RCLC_PARAMETER_BOOL);
-  EXPECT_EQ(RCL_RET_ERROR, rc);
+  ASSERT_EQ(rclc_add_parameter(&param_server, overflow_name, RCLC_PARAMETER_BOOL), RCL_RET_ERROR);
 
   // Add more parameters
-  rc = rclc_add_parameter(&param_server, "param2", RCLC_PARAMETER_INT);
+  ASSERT_EQ(rclc_add_parameter(&param_server, "param2", RCLC_PARAMETER_INT), RCL_RET_OK);
   param_names.push_back("param2");
-  EXPECT_EQ(RCL_RET_OK, rc);
 
-  rc = rclc_add_parameter(&param_server, "param3", RCLC_PARAMETER_DOUBLE);
+  ASSERT_EQ(rclc_add_parameter(&param_server, "param3", RCLC_PARAMETER_DOUBLE), RCL_RET_OK);
   param_names.push_back("param3");
-  EXPECT_EQ(RCL_RET_OK, rc);
 
-  rc = rclc_add_parameter(&param_server, "param4", RCLC_PARAMETER_DOUBLE);
+  ASSERT_EQ(rclc_add_parameter(&param_server, "param4", RCLC_PARAMETER_DOUBLE), RCL_RET_OK);
   param_names.push_back("param4");
-  EXPECT_EQ(RCL_RET_OK, rc);
 
   // Fail on too much params
-  rc = rclc_add_parameter(&param_server, "param5", RCLC_PARAMETER_DOUBLE);
-  EXPECT_EQ(RCL_RET_ERROR, rc);
+  ASSERT_EQ(rclc_add_parameter(&param_server, "param5", RCLC_PARAMETER_DOUBLE), RCL_RET_ERROR);
 
-  // Set parameters
-  expected_type = RCLC_PARAMETER_BOOL;
-  expected_value.bool_value = true;
-  rclc_parameter_set_bool(&param_server, "param1", static_cast<bool>(expected_value.bool_value));
+  // Destroy parameter server
+  ASSERT_EQ(rclc_parameter_server_fini(&param_server, &node), RCL_RET_OK);
+}
 
-  expected_type = RCLC_PARAMETER_INT;
-  expected_value.integer_value = 10;
-  rclc_parameter_set_int(&param_server, "param2", static_cast<int>(expected_value.integer_value));
-
-  expected_type = RCLC_PARAMETER_DOUBLE;
-  expected_value.double_value = 0.01;
-  rclc_parameter_set_double(
-    &param_server, "param3",
-    static_cast<double>(expected_value.double_value));
-
-  // Get parameters
-  bool param1;
-  int64_t param2;
-  double param3;
-
-  rclc_parameter_get_bool(&param_server, "param1", &param1);
-  ASSERT_EQ(param1, true);
-  rclc_parameter_get_int(&param_server, "param2", &param2);
-  ASSERT_EQ(param2, 10);
-  rclc_parameter_get_double(&param_server, "param3", &param3);
-  ASSERT_EQ(param3, 0.01);
-
-  ASSERT_EQ(callcack_calls, 3);
-
-  // Spin RCLC parameter server in a thread
-  bool spin = true;
-  std::thread rclc_parameter_server_thread(
-    [&]() -> void {
-      while (spin) {
-        ASSERT_EQ(rclc_executor_spin_some(&executor, RCL_MS_TO_NS(100)), RCL_RET_OK);
-      }
+class ParameterTestBase : public ::testing::Test
+{
+public:
+    ParameterTestBase()
+      : default_spin_timeout( std::chrono::duration<int64_t, std::milli>(10000))
+    {
+      callcack_calls = 0;
+      user_return = true;
+      old_parameter_name = "";
+      new_parameter_name = "";
+      new_parameter_value.type = RCLC_PARAMETER_NOT_SET;
+      old_parameter_value.type = RCLC_PARAMETER_NOT_SET;
     }
-  );
 
-  // Use auxiliar RCLCPP node for check
-  auto list_params = parameters_client->list_parameters({}, 10);
-  ASSERT_EQ(list_params.names.size(), 4u);
+    ~ParameterTestBase(){}
+
+    void SetUp() override {
+      std::string node_name("test_node");
+
+      // Init RCLC support
+      rcl_allocator_t allocator = rcl_get_default_allocator();
+      EXPECT_EQ(rclc_support_init(&support, 0, nullptr, &allocator), RCL_RET_OK);
+
+      // Init node
+      EXPECT_EQ(rclc_node_init_default(&node, node_name.c_str(), "", &support), RCL_RET_OK);
+
+      // Init parameter server with allow_undeclared_parameters flag
+      rclc_parameter_options_t options;
+      options.notify_changed_over_dds = true;
+      options.max_params = 4;
+      options.allow_undeclared_parameters = true;
+
+      // Init parameter server
+      EXPECT_EQ(rclc_parameter_server_init_with_option(&param_server, &node, &options), RCL_RET_OK);
+
+      // Add parameter to executor
+      rclc_executor_init(
+        &executor, &support.context, RCLC_PARAMETER_EXECUTOR_HANDLES_NUMBER,
+        &allocator);
+      EXPECT_EQ(rclc_executor_add_parameter_server(&executor, &param_server, ParameterTestBase::on_parameter_changed), RCL_RET_OK);
+
+      // Add initial parameters
+      EXPECT_EQ(rclc_add_parameter(&param_server, "param1", RCLC_PARAMETER_BOOL), RCL_RET_OK);
+      EXPECT_EQ(rclc_add_parameter(&param_server, "param2", RCLC_PARAMETER_INT), RCL_RET_OK);
+      EXPECT_EQ(rclc_add_parameter(&param_server, "param3", RCLC_PARAMETER_DOUBLE), RCL_RET_OK);
+
+      // Spin RCLC parameter server in a thread
+      spin = true;
+      rclc_parameter_server_thread = std::thread([&]() -> void {
+          while (spin) {
+            ASSERT_EQ(rclc_executor_spin_some(&executor, RCL_MS_TO_NS(500)), RCL_RET_OK);
+          }
+        }
+      );
+
+      // Init rclcpp node
+      rclcpp::init(0, NULL);
+      param_client_node = std::make_shared<rclcpp::Node>("param_aux_client");
+      parameters_client = std::make_shared<rclcpp::SyncParametersClient>(
+        param_client_node,
+        node_name);
+
+      ASSERT_TRUE(parameters_client->wait_for_service(default_spin_timeout));
+      std::this_thread::sleep_for(500ms);
+    }
+
+    void TearDown() override {
+      rclcpp::shutdown();
+
+      spin = false;
+      rclc_parameter_server_thread.join();
+
+      // Destroy parameter server
+      ASSERT_EQ(rclc_parameter_server_fini(&param_server, &node), RCL_RET_OK);
+    }
+
+    static bool on_parameter_changed(const Parameter * old_param, const Parameter * new_param)
+    {
+      if (new_param == NULL) {
+        new_parameter_name = "null";
+        new_parameter_value.type = RCLC_PARAMETER_NOT_SET;
+      } else {
+        rclc_parameter_value_copy(&new_parameter_value, &new_param->value);
+        new_parameter_name = new_param->name.data;
+      }
+
+      if (old_param == NULL) {
+        old_parameter_name = "null";
+        old_parameter_value.type = RCLC_PARAMETER_NOT_SET;
+      } else {
+        rclc_parameter_value_copy(&old_parameter_value, &old_param->value);
+        old_parameter_name = old_param->name.data;
+      }
+
+      callcack_calls++;
+      return user_return;
+    }
+
+protected:
+    // Callback
+    static int callcack_calls;
+    static bool user_return;
+    static std::string old_parameter_name;
+    static std::string new_parameter_name;
+    static ParameterValue new_parameter_value;
+    static ParameterValue old_parameter_value;
+
+    // Rclcpp
+    std::shared_ptr<rclcpp::Node> param_client_node;
+    std::shared_ptr<rclcpp::SyncParametersClient> parameters_client;    
+    std::chrono::duration<int64_t, std::milli> default_spin_timeout;
+
+    // Rclc
+    rclc_support_t support;
+    rcl_node_t node;
+    rclc_executor_t executor;
+    rclc_parameter_server_t param_server;
+    std::thread rclc_parameter_server_thread;
+    bool spin;
+};
+
+int ParameterTestBase::callcack_calls;
+bool ParameterTestBase::user_return;
+std::string ParameterTestBase::old_parameter_name;
+std::string ParameterTestBase::new_parameter_name;
+ParameterValue ParameterTestBase::new_parameter_value;
+ParameterValue ParameterTestBase::old_parameter_value;
+
+TEST_F(ParameterTestBase, rclc_set_get_parameter) {
+  int expected_callcack_calls = 1;
+  
+  // Set parameters
+  {
+    const char * param_name = "param1";
+    bool set_value = true;
+    bool get_value;
+
+    // Get initial value
+    ASSERT_EQ(rclc_parameter_get_bool(&param_server, param_name, &get_value), RCL_RET_OK);
+    ASSERT_EQ(get_value, false);
+
+    // Set value
+    ASSERT_EQ(rclc_parameter_set_bool(&param_server, param_name, set_value), RCL_RET_OK);
+    ASSERT_EQ(old_parameter_name, param_name);
+    ASSERT_EQ(new_parameter_name, param_name);
+    ASSERT_EQ(old_parameter_value.type, RCLC_PARAMETER_BOOL);
+    ASSERT_EQ(new_parameter_value.type, RCLC_PARAMETER_BOOL);
+    ASSERT_EQ(old_parameter_value.bool_value, get_value);
+    ASSERT_EQ(new_parameter_value.bool_value, set_value);
+    ASSERT_EQ(callcack_calls, expected_callcack_calls);
+    expected_callcack_calls++;
+
+    // Get new value
+    ASSERT_EQ(rclc_parameter_get_bool(&param_server, param_name, &get_value), RCL_RET_OK);
+    ASSERT_EQ(set_value, get_value);
+  }
+
+  {
+    const char * param_name = "param2";
+    int set_value = 10;
+    int get_value;
+  
+    // Get initial value
+    ASSERT_EQ(rclc_parameter_get_int(&param_server, param_name, &get_value), RCL_RET_OK);
+    ASSERT_EQ(get_value, 0);
+
+    // Set value
+    ASSERT_EQ(rclc_parameter_set_int(&param_server, param_name, set_value), RCL_RET_OK);
+    ASSERT_EQ(old_parameter_name, param_name);
+    ASSERT_EQ(new_parameter_name, param_name);
+    ASSERT_EQ(old_parameter_value.type, RCLC_PARAMETER_INT);
+    ASSERT_EQ(new_parameter_value.type, RCLC_PARAMETER_INT);
+    ASSERT_EQ(old_parameter_value.integer_value, 0);
+    ASSERT_EQ(new_parameter_value.integer_value, set_value);
+    ASSERT_EQ(callcack_calls, expected_callcack_calls);
+    expected_callcack_calls++;
+
+    // Get new value
+    ASSERT_EQ(rclc_parameter_get_int(&param_server, param_name, &get_value), RCL_RET_OK);
+    ASSERT_EQ(set_value, get_value);
+  }
+
+  {
+    const char * param_name = "param3";
+    double set_value = 0.01;
+    double get_value;
+  
+    // Get initial value
+    ASSERT_EQ(rclc_parameter_get_double(&param_server, param_name, &get_value), RCL_RET_OK);
+    ASSERT_EQ(get_value, 0.0);
+
+    // Set value
+    ASSERT_EQ(rclc_parameter_set_double(
+      &param_server, param_name, set_value), RCL_RET_OK);
+    ASSERT_EQ(old_parameter_name, param_name);
+    ASSERT_EQ(new_parameter_name, param_name);
+    ASSERT_EQ(old_parameter_value.type, RCLC_PARAMETER_DOUBLE);
+    ASSERT_EQ(new_parameter_value.type, RCLC_PARAMETER_DOUBLE);
+    ASSERT_EQ(old_parameter_value.double_value, 0.0);
+    ASSERT_EQ(new_parameter_value.double_value, set_value);
+    ASSERT_EQ(callcack_calls, expected_callcack_calls);
+    expected_callcack_calls++;
+
+    // Get new value
+    ASSERT_EQ(rclc_parameter_get_double(&param_server, param_name, &get_value), RCL_RET_OK);
+    ASSERT_EQ(set_value, get_value);
+  }
+
+  // Fail with user reject
+  user_return = false;
+  {
+    const char * param_name = "param3";
+    double set_value = 0.05;
+    double first_get_value;
+    double second_get_value;
+
+    // Get initial value
+    ASSERT_EQ(rclc_parameter_get_double(&param_server, param_name, &first_get_value), RCL_RET_OK);
+
+    // Set value
+    ASSERT_EQ(rclc_parameter_set_double(&param_server, param_name, set_value), PARAMETER_MODIFICATION_REJECTED);
+    ASSERT_EQ(callcack_calls, 4);
+
+    // Get value
+    ASSERT_EQ(rclc_parameter_get_double(&param_server, param_name, &second_get_value), RCL_RET_OK);
+    ASSERT_EQ(first_get_value, second_get_value);
+  }
+}
+
+TEST_F(ParameterTestBase, rclcpp_set_get_parameter) {
+  int expected_callcack_calls = 1;
+
+  // List parameters check
+  std::vector<std::string> param_names = {"param1", "param2", "param3"};
+  auto list_params = parameters_client->list_parameters({}, 4, default_spin_timeout);
+  ASSERT_EQ(list_params.names.size(), param_names.size());
   for (auto & name : list_params.names) {
     std::vector<std::string>::iterator it;
     it = std::find(param_names.begin(), param_names.end(), name);
     ASSERT_NE(it, param_names.end());
   }
 
-  const std::string name("param1");
-  const bool defaultvalue = 0;
-  bool param_value = parameters_client->get_parameter(name, defaultvalue);
-  ASSERT_EQ(param_value, true);
+  // Set parameters
+  {
+    std::vector<rclcpp::Parameter> param = {rclcpp::Parameter(param_names[0], true)};
+    const std::string param_name = param[0].get_name();
 
-  // External set bool
-  expected_type = RCLC_PARAMETER_BOOL;
-  expected_value.bool_value = false;
-  std::vector<rclcpp::Parameter> new_params =
-  {rclcpp::Parameter("param1", expected_value.bool_value)};
-  std::vector<rcl_interfaces::msg::SetParametersResult> result = parameters_client->set_parameters(
-    new_params);
-  ASSERT_TRUE(result[0].successful);
+    // Get initial value
+    bool get_value = parameters_client->get_parameter<bool>(param_name);
+    ASSERT_EQ(get_value, false);
 
-  // External fail type
-  new_params.clear();
-  new_params.push_back(rclcpp::Parameter("param1", static_cast<double>(12.2)));
-  result = parameters_client->set_parameters(new_params);
+    // Set value
+    auto result = parameters_client->set_parameters(param, default_spin_timeout);
+    ASSERT_FALSE(result.empty());
+    ASSERT_TRUE(result[0].successful);
+    ASSERT_EQ(result[0].reason, "");
+
+    // Check callback values
+    ASSERT_EQ(callcack_calls, expected_callcack_calls);
+    ASSERT_EQ(new_parameter_value.type, RCLC_PARAMETER_BOOL);
+    ASSERT_EQ(new_parameter_name, param_name);
+    ASSERT_EQ(new_parameter_value.bool_value, param[0].as_bool());
+    expected_callcack_calls++;
+  
+    // Get new value
+    get_value = parameters_client->get_parameter<bool>(param_name);
+    ASSERT_EQ(param[0].as_bool(), get_value);
+  }
+
+  {
+    std::vector<rclcpp::Parameter> param = {rclcpp::Parameter(param_names[1], 10)};
+    const std::string param_name = param[0].get_name();
+
+    // Get initial value
+    int get_value = parameters_client->get_parameter<int>(param_name);
+    ASSERT_EQ(get_value, false);
+
+    // Set value
+    auto result = parameters_client->set_parameters(param, default_spin_timeout);
+    ASSERT_FALSE(result.empty());
+    ASSERT_TRUE(result[0].successful);
+    ASSERT_EQ(result[0].reason, "");
+  
+    // Check callback values
+    ASSERT_EQ(callcack_calls, expected_callcack_calls);
+    ASSERT_EQ(new_parameter_value.type, RCLC_PARAMETER_INT);
+    ASSERT_EQ(new_parameter_name, param_name);
+    ASSERT_EQ(new_parameter_value.integer_value, param[0].as_int());
+    expected_callcack_calls++;
+
+    // Get new value
+    get_value = parameters_client->get_parameter<int>(param_name);
+    ASSERT_EQ(param[0].as_int(), get_value);
+  }
+
+  {
+    std::vector<rclcpp::Parameter> param = {rclcpp::Parameter(param_names[2], -0.01)};
+    const std::string param_name = param[0].get_name();
+  
+    // Get initial value
+    double get_value = parameters_client->get_parameter<double>(param_name);
+    ASSERT_EQ(get_value, false);
+
+    // Set value
+    auto result = parameters_client->set_parameters(param, default_spin_timeout);
+    ASSERT_FALSE(result.empty());
+    ASSERT_TRUE(result[0].successful);
+    ASSERT_EQ(result[0].reason, "");
+  
+    // Check callback values
+    ASSERT_EQ(callcack_calls, expected_callcack_calls);
+    ASSERT_EQ(new_parameter_value.type, RCLC_PARAMETER_DOUBLE);
+    ASSERT_EQ(new_parameter_name, param_name);
+    ASSERT_EQ(new_parameter_value.double_value, param[0].as_double());
+    expected_callcack_calls++;
+  
+    // Get new value
+    get_value = parameters_client->get_parameter<double>(param_name);
+    ASSERT_EQ(param[0].as_double(), get_value);
+  }
+
+  // Fail with user reject
+  user_return = false;
+  {
+    std::vector<rclcpp::Parameter> param = {rclcpp::Parameter(param_names[2], -0.05)};
+    const std::string param_name = param[0].get_name();
+    
+    // Get initial value
+    double first_get_value = parameters_client->get_parameter<double>(param_name);
+
+    // Set value
+    auto result = parameters_client->set_parameters(param, default_spin_timeout);
+    ASSERT_FALSE(result.empty());
+    ASSERT_FALSE(result[0].successful);
+    ASSERT_EQ(result[0].reason, "Rejected by server");
+    ASSERT_EQ(callcack_calls, expected_callcack_calls);
+    expected_callcack_calls++;
+
+    // Get value
+    double second_get_value = parameters_client->get_parameter<double>(param_name);
+    ASSERT_EQ(first_get_value, second_get_value);
+  }
+}
+
+TEST_F(ParameterTestBase, rclc_delete_parameter) {
+  // Get parameter
+  const char * param_name = "param1";
+  bool param_value;
+
+  ASSERT_EQ(rclc_parameter_get_bool(&param_server, param_name, &param_value), RCL_RET_OK);
+
+  // Delete parameter
+  EXPECT_EQ(rclc_delete_parameter(&param_server, param_name), RCL_RET_OK);
+
+  // Get deleted parameter
+  ASSERT_EQ(rclc_parameter_get_bool(&param_server, param_name, &param_value), RCL_RET_ERROR);
+}
+
+TEST_F(ParameterTestBase, rclcpp_delete_parameter) {
+  int expected_callcack_calls = 1;
+
+  // Use RCLCPP to delete and check parameters
+  user_return = false;
+  const std::vector<std::string> parameters = { "param1" };
+  auto result = parameters_client->delete_parameters(parameters, default_spin_timeout);
+  ASSERT_FALSE(result.empty());
   ASSERT_FALSE(result[0].successful);
+  ASSERT_EQ(result[0].reason, "Rejected by server");
+  ASSERT_EQ(callcack_calls, expected_callcack_calls);
+  expected_callcack_calls++;
 
-  // External set int
-  expected_type = RCLC_PARAMETER_INT;
-  expected_value.integer_value = 12;
-  new_params.clear();
-  new_params.push_back(rclcpp::Parameter("param2", expected_value.integer_value));
-  result = parameters_client->set_parameters(new_params);
+  auto list_params = parameters_client->list_parameters({}, 4, default_spin_timeout);
+  ASSERT_EQ(list_params.names.size(), 3u);
+  ASSERT_EQ(list_params.names[0], parameters[0]);
+
+  user_return = true;
+  result = parameters_client->delete_parameters(parameters, default_spin_timeout);
+  ASSERT_FALSE(result.empty());
   ASSERT_TRUE(result[0].successful);
+  ASSERT_EQ(result[0].reason, "");
+  ASSERT_EQ(callcack_calls, expected_callcack_calls);
+  expected_callcack_calls++;
 
-  // External set double
-  expected_type = RCLC_PARAMETER_DOUBLE;
-  expected_value.double_value = 12.12;
-  new_params.clear();
-  new_params.push_back(rclcpp::Parameter("param3", expected_value.double_value));
-  result = parameters_client->set_parameters(new_params);
+  // Use auxiliar RCLCPP node for check
+  list_params = parameters_client->list_parameters({}, 4, default_spin_timeout);
+  ASSERT_EQ(list_params.names.size(), 2U);
+  ASSERT_EQ(std::find(list_params.names.begin(), list_params.names.end(), parameters[0]), list_params.names.end());
+}
+
+TEST_F(ParameterTestBase, rclcpp_add_parameter) {
+  int expected_callcack_calls = 1;
+ 
+  // Reject add parameter
+  user_return = false;
+  std::vector<rclcpp::Parameter> param =
+  {rclcpp::Parameter("param4", 10.5)};
+  auto result = parameters_client->set_parameters(param, default_spin_timeout);
+  ASSERT_FALSE(result.empty());
+  ASSERT_FALSE(result[0].successful);
+  ASSERT_EQ(result[0].reason, "New parameter rejected");
+  ASSERT_EQ(callcack_calls, expected_callcack_calls);
+  expected_callcack_calls++;
+
+  auto list_params = parameters_client->list_parameters({}, 4, default_spin_timeout);
+  ASSERT_EQ(list_params.names.size(), 3u);
+  ASSERT_EQ(std::find(list_params.names.begin(), list_params.names.end(), param[0].get_name()), list_params.names.end());
+  
+  // Accept add parameter
+  user_return = true;
+  result = parameters_client->set_parameters(param, default_spin_timeout);
+  ASSERT_FALSE(result.empty());
   ASSERT_TRUE(result[0].successful);
+  ASSERT_EQ(result[0].reason, "New parameter added");
+  ASSERT_EQ(callcack_calls, expected_callcack_calls);
 
+  list_params = parameters_client->list_parameters({}, 4, default_spin_timeout);
+  ASSERT_EQ(list_params.names.size(), 4u);
+  ASSERT_EQ(list_params.names[3], param[0].get_name());
+
+  // Check value and type
+  double param_value = parameters_client->get_parameter<double>(param[0].get_name());
+  ASSERT_EQ(param_value, 10.5);
+
+  // Reject parameter on full server
+  user_return = false;
+  param.clear();
+  param.push_back(rclcpp::Parameter("param5", 12.2));
+  result = parameters_client->set_parameters(param, default_spin_timeout);
+  ASSERT_FALSE(result.empty());
+  ASSERT_FALSE(result[0].successful);
+  ASSERT_EQ(result[0].reason, "Parameter server is full");
+  ASSERT_EQ(callcack_calls, expected_callcack_calls);
+}
+
+TEST_F(ParameterTestBase, notify_changed_over_dds) {
+  // Subscribe to on_parameter_event
+  auto promise = std::make_shared<std::promise<void>>();
+  auto future = promise->get_future().share();
+  bool parameter_change = false;
+  bool parameter_added = false;
+  bool parameter_deleted = false;
+
+  auto sub = parameters_client->on_parameter_event(
+    [&](const rcl_interfaces::msg::ParameterEvent::SharedPtr event ) -> void
+    {
+      parameter_change = event->changed_parameters.size() > 0;
+      parameter_added = event->new_parameters.size() > 0;
+      parameter_deleted = event->deleted_parameters.size() > 0;
+      promise->set_value();
+    });
+
+  ASSERT_EQ(rclc_parameter_set_bool(&param_server, "param1", false), RCL_RET_OK);
+  ASSERT_EQ(rclcpp::spin_until_future_complete(param_client_node, future, default_spin_timeout), rclcpp::FutureReturnCode::SUCCESS);
+  ASSERT_TRUE(parameter_change);
+  ASSERT_FALSE(parameter_added);
+  ASSERT_FALSE(parameter_deleted);
+}
+
+TEST_F(ParameterTestBase, rclcpp_get_parameter_types) {
   // External get types
   const std::vector<std::string> types_query = {
     "param1",
     "param2",
     "param3"
   };
-  std::vector<rclcpp::ParameterType> types = parameters_client->get_parameter_types(types_query);
+  std::vector<rclcpp::ParameterType> types = parameters_client->get_parameter_types(types_query, default_spin_timeout);
   ASSERT_EQ(types.size(), 3u);
   ASSERT_EQ(types[0], rclcpp::ParameterType::PARAMETER_BOOL);
   ASSERT_EQ(types[1], rclcpp::ParameterType::PARAMETER_INTEGER);
   ASSERT_EQ(types[2], rclcpp::ParameterType::PARAMETER_DOUBLE);
-
-  // Test callback
-  auto promise = std::make_shared<std::promise<void>>();
-  auto future = promise->get_future();
-  size_t on_parameter_calls = 0;
-  auto sub = parameters_client->on_parameter_event(
-    [&](const rcl_interfaces::msg::ParameterEvent::SharedPtr /* event */) -> void
-    {
-      on_parameter_calls++;
-      promise->set_value();
-    });
-
-  expected_type = RCLC_PARAMETER_BOOL;
-  expected_value.double_value = false;
-  rclc_parameter_set_bool(&param_server, "param1", false);
-
-  rclcpp::spin_until_future_complete(param_client_node, future.share());
-
-  ASSERT_EQ(on_parameter_calls, 1u);
-
-  rclcpp::shutdown();
-
-  spin = false;
-  rclc_parameter_server_thread.join();
-
-  // Destroy parameter server
-  ASSERT_EQ(rclc_parameter_server_fini(&param_server, &node), RCL_RET_OK);
 }
+

--- a/rclc_parameter/test/rclc_parameter/test_parameter.cpp
+++ b/rclc_parameter/test/rclc_parameter/test_parameter.cpp
@@ -56,7 +56,7 @@ TEST(ParameterTestUnitary, rclc_parameter_server_init_default) {
   // Add parameter to executor
   rclc_executor_t executor;
   rclc_executor_init(
-    &executor, &support.context, RCLC_PARAMETER_EXECUTOR_HANDLES_NUMBER,
+    &executor, &support.context, RCLC_EXECUTOR_PARAMETER_SERVER_HANDLES,
     &allocator);
   ASSERT_EQ(rclc_executor_add_parameter_server(&executor, &param_server, nullptr), RCL_RET_OK);
 
@@ -133,7 +133,7 @@ public:
 
     // Add parameter to executor
     rclc_executor_init(
-      &executor, &support.context, RCLC_PARAMETER_EXECUTOR_HANDLES_NUMBER,
+      &executor, &support.context, RCLC_EXECUTOR_PARAMETER_SERVER_HANDLES,
       &allocator);
     EXPECT_EQ(
       rclc_executor_add_parameter_server_with_context(

--- a/rclc_parameter/test/rclc_parameter/test_parameter.cpp
+++ b/rclc_parameter/test/rclc_parameter/test_parameter.cpp
@@ -247,8 +247,8 @@ TEST_P(ParameterTestBase, rclc_set_get_parameter) {
 
   {
     const char * param_name = "param2";
-    int set_value = 10;
-    int get_value;
+    int64_t set_value = 10;
+    int64_t get_value;
 
     // Get initial value
     ASSERT_EQ(rclc_parameter_get_int(&param_server, param_name, &get_value), RCL_RET_OK);

--- a/rclc_parameter/test/rclc_parameter/test_parameter.cpp
+++ b/rclc_parameter/test/rclc_parameter/test_parameter.cpp
@@ -110,16 +110,10 @@ class ParameterTestBase : public ::testing::TestWithParam<rclc_parameter_options
 {
 public:
   ParameterTestBase()
-  : default_spin_timeout(std::chrono::duration<int64_t, std::milli>(10000)),
+  : callback_calls(0),
+    default_spin_timeout(std::chrono::duration<int64_t, std::milli>(10000)),
     options(GetParam())
-  {
-    callcack_calls = 0;
-    user_return = true;
-    strncpy(old_parameter_name, "", sizeof(old_parameter_name));
-    strncpy(new_parameter_name, "", sizeof(new_parameter_name));
-    new_parameter_value.type = RCLC_PARAMETER_NOT_SET;
-    old_parameter_value.type = RCLC_PARAMETER_NOT_SET;
-  }
+  {}
 
   ~ParameterTestBase() {}
 
@@ -142,9 +136,10 @@ public:
       &executor, &support.context, RCLC_PARAMETER_EXECUTOR_HANDLES_NUMBER,
       &allocator);
     EXPECT_EQ(
-      rclc_executor_add_parameter_server(
+      rclc_executor_add_parameter_server_with_context(
         &executor, &param_server,
-        ParameterTestBase::on_parameter_changed), RCL_RET_OK);
+        ParameterTestBase::callback_dispatcher,
+        this), RCL_RET_OK);
 
     // Add initial parameters
     EXPECT_EQ(rclc_add_parameter(&param_server, "param1", RCLC_PARAMETER_BOOL), RCL_RET_OK);
@@ -186,36 +181,20 @@ public:
     ASSERT_EQ(rcl_node_fini(&node), RCL_RET_OK);
   }
 
-  static bool on_parameter_changed(const Parameter * old_param, const Parameter * new_param)
+  static bool callback_dispatcher(
+    const Parameter * old_param, const Parameter * new_param,
+    void * context)
   {
-    if (new_param == NULL) {
-      strncpy(new_parameter_name, "null", sizeof(new_parameter_name));
-      new_parameter_value.type = RCLC_PARAMETER_NOT_SET;
-    } else {
-      strncpy(new_parameter_name, new_param->name.data, sizeof(new_parameter_name));
-      rclc_parameter_value_copy(&new_parameter_value, &new_param->value);
-    }
-
-    if (old_param == NULL) {
-      strncpy(old_parameter_name, "null", sizeof(old_parameter_name));
-      old_parameter_value.type = RCLC_PARAMETER_NOT_SET;
-    } else {
-      strncpy(old_parameter_name, old_param->name.data, sizeof(old_parameter_name));
-      rclc_parameter_value_copy(&old_parameter_value, &old_param->value);
-    }
-
-    callcack_calls++;
-    return user_return;
+    ParameterTestBase * obj = reinterpret_cast<ParameterTestBase *>(context);
+    obj->callback_calls++;
+    return obj->on_parameter_changed(old_param, new_param);
   }
 
 protected:
   // Callback
-  static int callcack_calls;
-  static bool user_return;
-  static char old_parameter_name[RCLC_PARAMETER_MAX_STRING_LENGTH];
-  static char new_parameter_name[RCLC_PARAMETER_MAX_STRING_LENGTH];
-  static ParameterValue new_parameter_value;
-  static ParameterValue old_parameter_value;
+  size_t callback_calls;
+  std::function<bool(const Parameter * old_param,
+    const Parameter * new_param)> on_parameter_changed;
 
   // Rclcpp
   std::shared_ptr<rclcpp::Node> param_client_node;
@@ -233,15 +212,8 @@ protected:
   bool spin;
 };
 
-int ParameterTestBase::callcack_calls;
-bool ParameterTestBase::user_return;
-char ParameterTestBase::old_parameter_name[] = "";
-char ParameterTestBase::new_parameter_name[] = "";
-ParameterValue ParameterTestBase::new_parameter_value;
-ParameterValue ParameterTestBase::old_parameter_value;
-
 TEST_P(ParameterTestBase, rclc_set_get_parameter) {
-  int expected_callcack_calls = 1;
+  size_t expected_callback_calls = 1;
 
   // Set parameters
   {
@@ -254,15 +226,19 @@ TEST_P(ParameterTestBase, rclc_set_get_parameter) {
     ASSERT_EQ(get_value, false);
 
     // Set value
+    on_parameter_changed = [&](const Parameter * old_param, const Parameter * new_param) -> bool {
+        EXPECT_EQ(strcmp(old_param->name.data, param_name), 0);
+        EXPECT_EQ(strcmp(new_param->name.data, param_name), 0);
+        EXPECT_EQ(old_param->value.type, RCLC_PARAMETER_BOOL);
+        EXPECT_EQ(new_param->value.type, RCLC_PARAMETER_BOOL);
+        EXPECT_EQ(old_param->value.bool_value, get_value);
+        EXPECT_EQ(new_param->value.bool_value, set_value);
+        return true;
+      };
+
     ASSERT_EQ(rclc_parameter_set_bool(&param_server, param_name, set_value), RCL_RET_OK);
-    ASSERT_EQ(strcmp(old_parameter_name, param_name), 0);
-    ASSERT_EQ(strcmp(new_parameter_name, param_name), 0);
-    ASSERT_EQ(old_parameter_value.type, RCLC_PARAMETER_BOOL);
-    ASSERT_EQ(new_parameter_value.type, RCLC_PARAMETER_BOOL);
-    ASSERT_EQ(old_parameter_value.bool_value, get_value);
-    ASSERT_EQ(new_parameter_value.bool_value, set_value);
-    ASSERT_EQ(callcack_calls, expected_callcack_calls);
-    expected_callcack_calls++;
+    EXPECT_EQ(callback_calls, expected_callback_calls);
+    expected_callback_calls++;
 
     // Get new value
     ASSERT_EQ(rclc_parameter_get_bool(&param_server, param_name, &get_value), RCL_RET_OK);
@@ -279,15 +255,19 @@ TEST_P(ParameterTestBase, rclc_set_get_parameter) {
     ASSERT_EQ(get_value, 0);
 
     // Set value
+    on_parameter_changed = [&](const Parameter * old_param, const Parameter * new_param) -> bool {
+        EXPECT_EQ(strcmp(old_param->name.data, param_name), 0);
+        EXPECT_EQ(strcmp(new_param->name.data, param_name), 0);
+        EXPECT_EQ(old_param->value.type, RCLC_PARAMETER_INT);
+        EXPECT_EQ(new_param->value.type, RCLC_PARAMETER_INT);
+        EXPECT_EQ(old_param->value.integer_value, get_value);
+        EXPECT_EQ(new_param->value.integer_value, set_value);
+        return true;
+      };
+
     ASSERT_EQ(rclc_parameter_set_int(&param_server, param_name, set_value), RCL_RET_OK);
-    ASSERT_EQ(strcmp(old_parameter_name, param_name), 0);
-    ASSERT_EQ(strcmp(new_parameter_name, param_name), 0);
-    ASSERT_EQ(old_parameter_value.type, RCLC_PARAMETER_INT);
-    ASSERT_EQ(new_parameter_value.type, RCLC_PARAMETER_INT);
-    ASSERT_EQ(old_parameter_value.integer_value, 0);
-    ASSERT_EQ(new_parameter_value.integer_value, set_value);
-    ASSERT_EQ(callcack_calls, expected_callcack_calls);
-    expected_callcack_calls++;
+    ASSERT_EQ(callback_calls, expected_callback_calls);
+    expected_callback_calls++;
 
     // Get new value
     ASSERT_EQ(rclc_parameter_get_int(&param_server, param_name, &get_value), RCL_RET_OK);
@@ -304,17 +284,21 @@ TEST_P(ParameterTestBase, rclc_set_get_parameter) {
     ASSERT_EQ(get_value, 0.0);
 
     // Set value
+    on_parameter_changed = [&](const Parameter * old_param, const Parameter * new_param) -> bool {
+        EXPECT_EQ(strcmp(old_param->name.data, param_name), 0);
+        EXPECT_EQ(strcmp(new_param->name.data, param_name), 0);
+        EXPECT_EQ(old_param->value.type, RCLC_PARAMETER_DOUBLE);
+        EXPECT_EQ(new_param->value.type, RCLC_PARAMETER_DOUBLE);
+        EXPECT_EQ(old_param->value.double_value, get_value);
+        EXPECT_EQ(new_param->value.double_value, set_value);
+        return true;
+      };
+
     ASSERT_EQ(
       rclc_parameter_set_double(
         &param_server, param_name, set_value), RCL_RET_OK);
-    ASSERT_EQ(strcmp(old_parameter_name, param_name), 0);
-    ASSERT_EQ(strcmp(new_parameter_name, param_name), 0);
-    ASSERT_EQ(old_parameter_value.type, RCLC_PARAMETER_DOUBLE);
-    ASSERT_EQ(new_parameter_value.type, RCLC_PARAMETER_DOUBLE);
-    ASSERT_EQ(old_parameter_value.double_value, 0.0);
-    ASSERT_EQ(new_parameter_value.double_value, set_value);
-    ASSERT_EQ(callcack_calls, expected_callcack_calls);
-    expected_callcack_calls++;
+    ASSERT_EQ(callback_calls, expected_callback_calls);
+    expected_callback_calls++;
 
     // Get new value
     ASSERT_EQ(rclc_parameter_get_double(&param_server, param_name, &get_value), RCL_RET_OK);
@@ -322,7 +306,6 @@ TEST_P(ParameterTestBase, rclc_set_get_parameter) {
   }
 
   // Fail with user reject
-  user_return = false;
   {
     const char * param_name = "param3";
     double set_value = 0.05;
@@ -333,11 +316,15 @@ TEST_P(ParameterTestBase, rclc_set_get_parameter) {
     ASSERT_EQ(rclc_parameter_get_double(&param_server, param_name, &first_get_value), RCL_RET_OK);
 
     // Set value
+    on_parameter_changed = [&](const Parameter *, const Parameter *) -> bool {
+        return false;
+      };
+
     ASSERT_EQ(
       rclc_parameter_set_double(
         &param_server, param_name,
-        set_value), PARAMETER_MODIFICATION_REJECTED);
-    ASSERT_EQ(callcack_calls, 4);
+        set_value), RCLC_PARAMETER_MODIFICATION_REJECTED);
+    ASSERT_EQ(callback_calls, expected_callback_calls);
 
     // Get value
     ASSERT_EQ(rclc_parameter_get_double(&param_server, param_name, &second_get_value), RCL_RET_OK);
@@ -346,7 +333,7 @@ TEST_P(ParameterTestBase, rclc_set_get_parameter) {
 }
 
 TEST_P(ParameterTestBase, rclcpp_set_get_parameter) {
-  int expected_callcack_calls = 1;
+  size_t expected_callback_calls = 1;
 
   // List parameters check
   std::vector<std::string> param_names = {"param1", "param2", "param3"};
@@ -367,18 +354,21 @@ TEST_P(ParameterTestBase, rclcpp_set_get_parameter) {
     bool get_value = parameters_client->get_parameter<bool>(param_name);
     ASSERT_EQ(get_value, false);
 
+    // Prepare RCLC callback
+    on_parameter_changed = [&](const Parameter *, const Parameter * new_param) -> bool {
+        EXPECT_EQ(new_param->value.type, RCLC_PARAMETER_BOOL);
+        EXPECT_EQ(strcmp(new_param->name.data, param_name.c_str()), 0);
+        EXPECT_EQ(new_param->value.bool_value, param[0].as_bool());
+        return true;
+      };
+
     // Set value
     auto result = parameters_client->set_parameters(param, default_spin_timeout);
     ASSERT_FALSE(result.empty());
     ASSERT_TRUE(result[0].successful);
     ASSERT_EQ(result[0].reason, "");
-
-    // Check callback values
-    ASSERT_EQ(callcack_calls, expected_callcack_calls);
-    ASSERT_EQ(new_parameter_value.type, RCLC_PARAMETER_BOOL);
-    ASSERT_EQ(new_parameter_name, param_name);
-    ASSERT_EQ(new_parameter_value.bool_value, param[0].as_bool());
-    expected_callcack_calls++;
+    ASSERT_EQ(callback_calls, expected_callback_calls);
+    expected_callback_calls++;
 
     // Get new value
     get_value = parameters_client->get_parameter<bool>(param_name);
@@ -393,6 +383,14 @@ TEST_P(ParameterTestBase, rclcpp_set_get_parameter) {
     int get_value = parameters_client->get_parameter<int>(param_name);
     ASSERT_EQ(get_value, false);
 
+    // Prepare RCLC callback
+    on_parameter_changed = [&](const Parameter *, const Parameter * new_param) -> bool {
+        EXPECT_EQ(new_param->value.type, RCLC_PARAMETER_INT);
+        EXPECT_EQ(strcmp(new_param->name.data, param_name.c_str()), 0);
+        EXPECT_EQ(new_param->value.integer_value, param[0].as_int());
+        return true;
+      };
+
     // Set value
     auto result = parameters_client->set_parameters(param, default_spin_timeout);
     ASSERT_FALSE(result.empty());
@@ -400,11 +398,8 @@ TEST_P(ParameterTestBase, rclcpp_set_get_parameter) {
     ASSERT_EQ(result[0].reason, "");
 
     // Check callback values
-    ASSERT_EQ(callcack_calls, expected_callcack_calls);
-    ASSERT_EQ(new_parameter_value.type, RCLC_PARAMETER_INT);
-    ASSERT_EQ(new_parameter_name, param_name);
-    ASSERT_EQ(new_parameter_value.integer_value, param[0].as_int());
-    expected_callcack_calls++;
+    ASSERT_EQ(callback_calls, expected_callback_calls);
+    expected_callback_calls++;
 
     // Get new value
     get_value = parameters_client->get_parameter<int>(param_name);
@@ -419,6 +414,14 @@ TEST_P(ParameterTestBase, rclcpp_set_get_parameter) {
     double get_value = parameters_client->get_parameter<double>(param_name);
     ASSERT_EQ(get_value, false);
 
+    // Prepare RCLC callback
+    on_parameter_changed = [&](const Parameter *, const Parameter * new_param) -> bool {
+        EXPECT_EQ(new_param->value.type, RCLC_PARAMETER_DOUBLE);
+        EXPECT_EQ(strcmp(new_param->name.data, param_name.c_str()), 0);
+        EXPECT_EQ(new_param->value.double_value, param[0].as_double());
+        return true;
+      };
+
     // Set value
     auto result = parameters_client->set_parameters(param, default_spin_timeout);
     ASSERT_FALSE(result.empty());
@@ -426,11 +429,8 @@ TEST_P(ParameterTestBase, rclcpp_set_get_parameter) {
     ASSERT_EQ(result[0].reason, "");
 
     // Check callback values
-    ASSERT_EQ(callcack_calls, expected_callcack_calls);
-    ASSERT_EQ(new_parameter_value.type, RCLC_PARAMETER_DOUBLE);
-    ASSERT_EQ(new_parameter_name, param_name);
-    ASSERT_EQ(new_parameter_value.double_value, param[0].as_double());
-    expected_callcack_calls++;
+    ASSERT_EQ(callback_calls, expected_callback_calls);
+    expected_callback_calls++;
 
     // Get new value
     get_value = parameters_client->get_parameter<double>(param_name);
@@ -438,7 +438,6 @@ TEST_P(ParameterTestBase, rclcpp_set_get_parameter) {
   }
 
   // Fail with user reject
-  user_return = false;
   {
     std::vector<rclcpp::Parameter> param = {rclcpp::Parameter(param_names[2], -0.05)};
     const std::string param_name = param[0].get_name();
@@ -446,13 +445,18 @@ TEST_P(ParameterTestBase, rclcpp_set_get_parameter) {
     // Get initial value
     double first_get_value = parameters_client->get_parameter<double>(param_name);
 
+    // Prepare RCLC callback
+    on_parameter_changed = [&](const Parameter *, const Parameter *) -> bool {
+        return false;
+      };
+
     // Set value
     auto result = parameters_client->set_parameters(param, default_spin_timeout);
     ASSERT_FALSE(result.empty());
     ASSERT_FALSE(result[0].successful);
     ASSERT_EQ(result[0].reason, "Rejected by server");
-    ASSERT_EQ(callcack_calls, expected_callcack_calls);
-    expected_callcack_calls++;
+    ASSERT_EQ(callback_calls, expected_callback_calls);
+    expected_callback_calls++;
 
     // Get value
     double second_get_value = parameters_client->get_parameter<double>(param_name);
@@ -465,6 +469,12 @@ TEST_P(ParameterTestBase, rclc_delete_parameter) {
   const char * param_name = "param1";
   bool param_value;
 
+  // Fail if callback is call
+  on_parameter_changed = [&](const Parameter *, const Parameter *) -> bool {
+      EXPECT_TRUE(false);  // Callback should not be called
+      return false;
+    };
+
   ASSERT_EQ(rclc_parameter_get_bool(&param_server, param_name, &param_value), RCL_RET_OK);
 
   // Delete parameter
@@ -475,32 +485,46 @@ TEST_P(ParameterTestBase, rclc_delete_parameter) {
 
   // Fail on deleted parameter
   EXPECT_EQ(rclc_delete_parameter(&param_server, param_name), RCL_RET_ERROR);
+
+  // No callback calls
+  ASSERT_EQ(callback_calls, 0U);
 }
 
 TEST_P(ParameterTestBase, rclcpp_delete_parameter) {
-  int expected_callcack_calls = 1;
+  size_t expected_callback_calls = 1;
 
   // Use RCLCPP to delete and check parameters
-  user_return = false;
   const std::vector<std::string> parameters = {"param1"};
+
+  on_parameter_changed = [&](const Parameter * old_param, const Parameter * new_param) -> bool {
+      EXPECT_NE(old_param, nullptr);
+      EXPECT_EQ(new_param, nullptr);
+      return false;
+    };
+
   auto result = parameters_client->delete_parameters(parameters, default_spin_timeout);
   ASSERT_FALSE(result.empty());
   ASSERT_FALSE(result[0].successful);
   ASSERT_EQ(result[0].reason, "Rejected by server");
-  ASSERT_EQ(callcack_calls, expected_callcack_calls);
-  expected_callcack_calls++;
+  ASSERT_EQ(callback_calls, expected_callback_calls);
+  expected_callback_calls++;
 
   auto list_params = parameters_client->list_parameters({}, 4, default_spin_timeout);
   ASSERT_EQ(list_params.names.size(), 3u);
   ASSERT_EQ(list_params.names[0], parameters[0]);
 
-  user_return = true;
+  on_parameter_changed = [&](const Parameter * old_param, const Parameter * new_param) -> bool {
+      EXPECT_NE(old_param, nullptr);
+      EXPECT_EQ(new_param, nullptr);
+      return true;
+    };
+
   result = parameters_client->delete_parameters(parameters, default_spin_timeout);
   ASSERT_FALSE(result.empty());
   ASSERT_TRUE(result[0].successful);
   ASSERT_EQ(result[0].reason, "");
-  ASSERT_EQ(callcack_calls, expected_callcack_calls);
-  expected_callcack_calls++;
+  ASSERT_EQ(callback_calls, expected_callback_calls);
+  expected_callback_calls++;
 
   // Use auxiliar RCLCPP node for check
   list_params = parameters_client->list_parameters({}, 4, default_spin_timeout);
@@ -508,23 +532,30 @@ TEST_P(ParameterTestBase, rclcpp_delete_parameter) {
   ASSERT_EQ(
     std::find(
       list_params.names.begin(),
-      list_params.names.end(), parameters[0]), list_params.names.end());
+      list_params.names.end(),
+      parameters[0]),
+    list_params.names.end());
 }
 
 TEST_P(ParameterTestBase, rclcpp_add_parameter) {
   std::vector<rclcpp::Parameter> param = {rclcpp::Parameter("param4", 10.5)};
 
   if (options.allow_undeclared_parameters) {
-    int expected_callcack_calls = 1;
+    size_t expected_callback_calls = 1;
 
     // Reject add parameter
-    user_return = false;
+    on_parameter_changed = [&](const Parameter * old_param, const Parameter * new_param) -> bool {
+        EXPECT_EQ(old_param, nullptr);
+        EXPECT_NE(new_param, nullptr);
+        return false;
+      };
+
     auto result = parameters_client->set_parameters(param, default_spin_timeout);
     ASSERT_FALSE(result.empty());
     ASSERT_FALSE(result[0].successful);
     ASSERT_EQ(result[0].reason, "New parameter rejected");
-    ASSERT_EQ(callcack_calls, expected_callcack_calls);
-    expected_callcack_calls++;
+    ASSERT_EQ(callback_calls, expected_callback_calls);
+    expected_callback_calls++;
 
     auto list_params = parameters_client->list_parameters({}, 4, default_spin_timeout);
     ASSERT_EQ(list_params.names.size(), 3u);
@@ -534,12 +565,17 @@ TEST_P(ParameterTestBase, rclcpp_add_parameter) {
         param[0].get_name()), list_params.names.end());
 
     // Accept add parameter
-    user_return = true;
+    on_parameter_changed = [&](const Parameter * old_param, const Parameter * new_param) -> bool {
+        EXPECT_EQ(old_param, nullptr);
+        EXPECT_NE(new_param, nullptr);
+        return true;
+      };
+
     result = parameters_client->set_parameters(param, default_spin_timeout);
     ASSERT_FALSE(result.empty());
     ASSERT_TRUE(result[0].successful);
     ASSERT_EQ(result[0].reason, "New parameter added");
-    ASSERT_EQ(callcack_calls, expected_callcack_calls);
+    ASSERT_EQ(callback_calls, expected_callback_calls);
 
     list_params = parameters_client->list_parameters({}, 4, default_spin_timeout);
     ASSERT_EQ(list_params.names.size(), 4u);
@@ -550,21 +586,30 @@ TEST_P(ParameterTestBase, rclcpp_add_parameter) {
     ASSERT_EQ(param_value, 10.5);
 
     // Reject parameter on full server
-    user_return = false;
+    on_parameter_changed = [&](const Parameter *, const Parameter *) -> bool {
+        EXPECT_TRUE(false);  // Callback should not be called
+        return false;
+      };
+
     param.clear();
     param.push_back(rclcpp::Parameter("param5", 12.2));
     result = parameters_client->set_parameters(param, default_spin_timeout);
     ASSERT_FALSE(result.empty());
     ASSERT_FALSE(result[0].successful);
     ASSERT_EQ(result[0].reason, "Parameter server is full");
-    ASSERT_EQ(callcack_calls, expected_callcack_calls);
+    ASSERT_EQ(callback_calls, expected_callback_calls);
   } else {
+    on_parameter_changed = [&](const Parameter *, const Parameter *) -> bool {
+        EXPECT_TRUE(false);  // Callback should not be called
+        return false;
+      };
+
     // Reject add parameter
     auto result = parameters_client->set_parameters(param, default_spin_timeout);
     ASSERT_FALSE(result.empty());
     ASSERT_FALSE(result[0].successful);
     ASSERT_EQ(result[0].reason, "Parameter not found");
-    ASSERT_EQ(callcack_calls, 0);
+    ASSERT_EQ(callback_calls, 0U);
 
     auto list_params = parameters_client->list_parameters({}, 4, default_spin_timeout);
     ASSERT_EQ(list_params.names.size(), 3u);
@@ -581,11 +626,16 @@ TEST_P(ParameterTestBase, rclcpp_read_only_parameter) {
   std::vector<rclcpp::Parameter> param = {rclcpp::Parameter("param2", 50)};
 
   // Reject set parameter on read only parameter
+  on_parameter_changed = [&](const Parameter *, const Parameter *) -> bool {
+      EXPECT_TRUE(false);  // Callback should not be called
+      return false;
+    };
+
   auto result = parameters_client->set_parameters(param, default_spin_timeout);
   ASSERT_FALSE(result.empty());
   ASSERT_FALSE(result[0].successful);
   ASSERT_EQ(result[0].reason, "Read only parameter");
-  ASSERT_EQ(callcack_calls, 0);
+  ASSERT_EQ(callback_calls, 0U);
 
   // Check read only flag on descriptor
   std::vector<std::string> params = {param[0].get_name()};
@@ -668,7 +718,9 @@ TEST_P(ParameterTestBase, rclcpp_parameter_description_low) {
 
   // Set parameter constrains
   ASSERT_EQ(
-    rclc_add_parameter_description(&param_server, "param2", "", ""), UNSUPORTED_ON_LOW_MEM);
+    rclc_add_parameter_description(
+      &param_server, "param2", "",
+      ""), RCLC_PARAMETER_UNSUPORTED_ON_LOW_MEM);
   ASSERT_EQ(
     rclc_add_parameter_constraints_integer(
       &param_server, "param2", int_from, int_to,
@@ -742,6 +794,10 @@ TEST_P(ParameterTestBase, notify_changed_over_dds) {
   std::this_thread::sleep_for(500ms);
 
   // Parameter change event
+  on_parameter_changed = [&](const Parameter *, const Parameter *) -> bool {
+      return true;
+    };
+
   ASSERT_EQ(rclc_parameter_set_bool(&param_server, "param1", false), RCL_RET_OK);
   ASSERT_EQ(
     rclcpp::spin_until_future_complete(

--- a/rclc_parameter/test/rclc_parameter/test_parameter.cpp
+++ b/rclc_parameter/test/rclc_parameter/test_parameter.cpp
@@ -721,6 +721,9 @@ TEST_P(ParameterTestBase, notify_changed_over_dds) {
       promise->set_value();
     });
 
+  // Sleep for pub/sub match
+  std::this_thread::sleep_for(500ms);
+
   ASSERT_EQ(rclc_parameter_set_bool(&param_server, "param1", false), RCL_RET_OK);
   ASSERT_EQ(
     rclcpp::spin_until_future_complete(

--- a/rclc_parameter/test/rclc_parameter/test_parameter.cpp
+++ b/rclc_parameter/test/rclc_parameter/test_parameter.cpp
@@ -470,8 +470,11 @@ TEST_P(ParameterTestBase, rclc_delete_parameter) {
   // Delete parameter
   EXPECT_EQ(rclc_delete_parameter(&param_server, param_name), RCL_RET_OK);
 
-  // Get deleted parameter
+  // Fail on get deleted parameter
   ASSERT_EQ(rclc_parameter_get_bool(&param_server, param_name, &param_value), RCL_RET_ERROR);
+
+  // Fail on deleted parameter
+  EXPECT_EQ(rclc_delete_parameter(&param_server, param_name), RCL_RET_ERROR);
 }
 
 TEST_P(ParameterTestBase, rclcpp_delete_parameter) {
@@ -635,9 +638,8 @@ TEST_P(ParameterTestBase, rclcpp_parameter_description) {
 
   ASSERT_EQ(description[1].name, params[1]);
   ASSERT_EQ(description[1].type, RCLC_PARAMETER_DOUBLE);
-  // TODO(acuadros95): Check empty string filled with spaces
-  // ASSERT_TRUE(description[1].description.empty());
-  // ASSERT_TRUE(description[1].additional_constraints.empty());
+  ASSERT_TRUE(description[1].description.empty());
+  ASSERT_TRUE(description[1].additional_constraints.empty());
   ASSERT_EQ(description[1].integer_range.size(), 0U);
   ASSERT_EQ(description[1].floating_point_range.size(), 1U);
   ASSERT_EQ(description[1].floating_point_range[0].from_value, double_from);


### PR DESCRIPTION
Functionality upgrade on micro-ROS parameters:
- Remove parameters: Using API and `ros2 param delete`
- Add new parameters with `ros2 param set`, configurable with option `allow_undeclared_parameters`
- Control of this features and parameter changes on user callback:
 https://github.com/ros2/rclc/blob/a79d5b84e5b86fd9c58cc0212a1c2a49fa8ca778/rclc_parameter/include/rclc_parameter/rclc_parameter.h#L77-L83
- Added `ros2 param describe`:
  - Parameter description
  - Constrains values and description
  - Read only parameters

- Added low memory mode, reducing the memory allocated with certain constrains:
  - Request size limited to 1 parameter on Set, Get, Get types and Describe services.
  - List parameters request has no prefixes enabled nor depth.
  - Parameter description strings not allowed. (`rclc_add_parameter_description`)

- Memory benchmark on STM32F4 for 7 parameters with `RCLC_PARAMETER_MAX_STRING_LENGTH = 50` and `notify_changed_over_dds = true`
    - Full mode: 11736 B
    - Low memory mode: 4160 B

- Test suite upgrade with parameterized `rclc_parameter_options_t` options.

- Update tutorials and documentation:
  - https://github.com/micro-ROS/micro-ROS.github.io/pull/366
  - https://github.com/micro-ROS/micro-ROS-demos/pull/62 