### PR TITLE
reverted to rolling distribution 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-20.04 ]
-        ros_distribution: [ humble ]
+        ros_distribution: [ rolling ]
         include:
           - docker_image: ubuntu:jammy
-            ros_distribution: humble
+            ros_distribution: rolling
     container:
       image: ${{ matrix.docker_image }}
     steps:


### PR DESCRIPTION
ci job reported with humble 'Error…Input has invalid distribution names.'

