### PR TITLE
added doxygen files

### DIFF
--- a/rclc/Doxyfile
+++ b/rclc/Doxyfile
@@ -1,0 +1,26 @@
+# All settings not listed here will use the Doxygen default values.
+
+PROJECT_NAME           = "rclc"
+PROJECT_NUMBER         = master
+PROJECT_BRIEF          = "RCLC API - C language frontend with convenience functions and Executor based on RCL"
+
+INPUT                  = ./include
+RECURSIVE              = YES
+OUTPUT_DIRECTORY       = doc_output
+
+SORT_MEMBER_DOCS       = NO
+
+GENERATE_LATEX         = NO
+
+ENABLE_PREPROCESSING   = YES
+MACRO_EXPANSION        = YES
+EXPAND_ONLY_PREDEF     = YES
+PREDEFINED             += RCLC_PUBLIC=
+
+# Tag files that do not exist will produce a warning and cross-project linking will not work.
+TAGFILES += "../../../../doxygen_tag_files/cppreference-doxygen-web.tag.xml=http://en.cppreference.com/w/"
+# Consider changing "latest" to the version you want to reference (e.g. beta1 or 1.0.0)
+TAGFILES += "../../../../doxygen_tag_files/rcl.tag=http://docs.ros2.org/latest/api/rcl/"
+TAGFILES += "../../../../doxygen_tag_files/rcutils.tag=http://docs.ros2.org/latest/api/rcutils/"
+# Uncomment to generate tag files for cross-project linking.
+GENERATE_TAGFILE = "../../../../doxygen_tag_files/rclc.tag"

--- a/rclc_lifecycle/Doxyfile
+++ b/rclc_lifecycle/Doxyfile
@@ -1,0 +1,26 @@
+# All settings not listed here will use the Doxygen default values.
+
+PROJECT_NAME           = "rclc_lifecycle"
+PROJECT_NUMBER         = master
+PROJECT_BRIEF          = "RCLC API - C language frontend for rcl lifecycle"
+
+INPUT                  = ./include
+RECURSIVE              = YES
+OUTPUT_DIRECTORY       = doc_output
+
+SORT_MEMBER_DOCS       = NO
+
+GENERATE_LATEX         = NO
+
+ENABLE_PREPROCESSING   = YES
+MACRO_EXPANSION        = YES
+EXPAND_ONLY_PREDEF     = YES
+PREDEFINED             += RCLC_LIFECYCLE_PUBLIC=
+
+# Tag files that do not exist will produce a warning and cross-project linking will not work.
+TAGFILES += "../../../../doxygen_tag_files/cppreference-doxygen-web.tag.xml=http://en.cppreference.com/w/"
+# Consider changing "latest" to the version you want to reference (e.g. beta1 or 1.0.0)
+TAGFILES += "../../../../doxygen_tag_files/rcl.tag=http://docs.ros2.org/latest/api/rcl/"
+TAGFILES += "../../../../doxygen_tag_files/rcutils.tag=http://docs.ros2.org/latest/api/rcutils/"
+# Uncomment to generate tag files for cross-project linking.
+GENERATE_TAGFILE = "../../../../doxygen_tag_files/rclc_lifecycle.tag"

--- a/rclc_parameter/Doxyfile
+++ b/rclc_parameter/Doxyfile
@@ -1,0 +1,26 @@
+# All settings not listed here will use the Doxygen default values.
+
+PROJECT_NAME           = "rclc_parameter"
+PROJECT_NUMBER         = master
+PROJECT_BRIEF          = "RCLC API - C language frontend for rcl parameters"
+
+INPUT                  = ./include
+RECURSIVE              = YES
+OUTPUT_DIRECTORY       = doc_output
+
+SORT_MEMBER_DOCS       = NO
+
+GENERATE_LATEX         = NO
+
+ENABLE_PREPROCESSING   = YES
+MACRO_EXPANSION        = YES
+EXPAND_ONLY_PREDEF     = YES
+PREDEFINED             += RCLC_PARAMETER_PUBLIC=
+
+# Tag files that do not exist will produce a warning and cross-project linking will not work.
+TAGFILES += "../../../../doxygen_tag_files/cppreference-doxygen-web.tag.xml=http://en.cppreference.com/w/"
+# Consider changing "latest" to the version you want to reference (e.g. beta1 or 1.0.0)
+TAGFILES += "../../../../doxygen_tag_files/rcl.tag=http://docs.ros2.org/latest/api/rcl/"
+TAGFILES += "../../../../doxygen_tag_files/rcutils.tag=http://docs.ros2.org/latest/api/rcutils/"
+# Uncomment to generate tag files for cross-project linking.
+GENERATE_TAGFILE = "../../../../doxygen_tag_files/rclc_parameter.tag"


### PR DESCRIPTION
improve documentation on http://docs.ros.org/en/humble/p/rclc/

without Doxygen file, no documenation is generated. Probably because `RCLC_PUBLIC `macro is creating the error message, see e.g. http://docs.ros.org/en/humble/p/rclc/generated/function_action__client_8h_1aa128dfa202ae13dce2633e4b92e5f004.html