### PR TITLE
[humble] prepare bloom release 4.0.1

### DIFF
--- a/rclc/CHANGELOG.rst
+++ b/rclc/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package rclc
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+4.0.1 (2022-07-20)
+------------------
+* updated documentation bloom build status table (#291) (#292)
+* updated os-version to ubuntu-22.04 (#295)
+* [rolling] updated ros-tooling versions (backport #289) (#297)
+* improved doxygen-generated API documentation (#301) (#302)
+
 4.0.0 (2022-04-28)
 ------------------
 * updated version for Humble release

--- a/rclc/package.xml
+++ b/rclc/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>rclc</name>
-  <version>4.0.0</version>
+  <version>4.0.1</version>
   <description>The ROS client library in C.</description>
   <maintainer email="jan.staschulat@de.bosch.com">Jan Staschulat</maintainer>
   <maintainer email="pablogarrido@eprosima.com">Pablo Garrido</maintainer>

--- a/rclc_examples/CHANGELOG.rst
+++ b/rclc_examples/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package rclc_examples
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+4.0.1 (2022-07-20)
+------------------
+* no changes
+
 4.0.0 (2022-04-28)
 ------------------
 * updated version for Humble release

--- a/rclc_examples/package.xml
+++ b/rclc_examples/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>rclc_examples</name>
-  <version>4.0.0</version>
+  <version>4.0.1</version>
   <description>Example of using rclc_executor</description>
   <maintainer email="jan.staschulat@de.bosch.com">Jan Staschulat</maintainer>
 

--- a/rclc_lifecycle/CHANGELOG.rst
+++ b/rclc_lifecycle/CHANGELOG.rst
@@ -1,6 +1,11 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package rclc_lifecycle
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+4.0.1 (2022-07-20)
+------------------
+* improved doxygen-generated API documentation (#301) (#302)
+
 4.0.0 (2022-04-28)
 ------------------
 * updated version for Humble release

--- a/rclc_lifecycle/package.xml
+++ b/rclc_lifecycle/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rclc_lifecycle</name>
-  <version>4.0.0</version>
+  <version>4.0.1</version>
   <description>rclc lifecycle convenience methods.</description>
   <maintainer email="jan.staschulat@de.bosch.com">Jan Staschulat</maintainer>
 

--- a/rclc_parameter/CHANGELOG.rst
+++ b/rclc_parameter/CHANGELOG.rst
@@ -1,6 +1,11 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package rclc_parameter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+4.0.1 (2022-07-20)
+------------------
+* improved doxygen-generated API documentation (#301) (#302)
+
 4.0.0 (2022-04-28)
 ------------------
 * updated version for Humble release

--- a/rclc_parameter/package.xml
+++ b/rclc_parameter/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rclc_parameter</name>
-  <version>4.0.0</version>
+  <version>4.0.1</version>
   <description>Parameter server implementation for micro-ROS nodes</description>
   <maintainer email="antoniocuadros@eprosima.com">Antonio Cuadros</maintainer>
 


### PR DESCRIPTION
- updated bloom release build status table 
- added doxygen file to improve rclc API documentation at [http://docs.ros.org/en/humble/p/rclc/](http://docs.ros.org/en/humble/p/rclc/)
- updated build-farm tooling