### PR TITLE
Drop build dependency on std_msgs

### DIFF
--- a/rclc/CMakeLists.txt
+++ b/rclc/CMakeLists.txt
@@ -32,7 +32,6 @@ find_package(rcl REQUIRED)
 find_package(rcl_action REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rosidl_generator_c REQUIRED)
-find_package(std_msgs REQUIRED)
 
 if("${rcl_VERSION}" VERSION_LESS "1.0.0")
   message(STATUS


### PR DESCRIPTION
This dependency is only needed when BUILD_TESTING is specified, and is already found via find_package() there.

Building packages with -DBUILD_TESTING=OFF should succeed in the absence of <test_depends> dependencies, which is why this issue came to my attention.

This change should be backported to Humble to avoid breaking the deb builds when we disable tests in the near future.