### PR TITLE
Update documentation about number_of_handles

### DIFF
--- a/rclc/README.md
+++ b/rclc/README.md
@@ -360,8 +360,9 @@ During the configuration phase, the user shall define:
 - trigger condition (optional, default: ANY)
 - data communcation semantics (optional, default ROS2)
 
-As the Executor is intended for embedded controllers, dynamic memory management is crucial. Therefore at initialization of the rclc Executor, the user defines the total number of callbacks. The necessary dynamic memory will be allocated only in this phase and no more memory in the running phase. This makes this Executor static in the sense, that during runtime no additional callbacks can be added. Also in the XRCE-DDS middleware the maximum number
-of handles need to be configured. See [Memory Management Tutorial](https://docs.vulcanexus.org/en/humble/rst/tutorials/micro/memory_management/memory_management.html#entity-creation) for the defaults and configuration of the colcon.meta configuration file.
+As the Executor is intended for embedded controllers, dynamic memory management is crucial. Therefore at initialization of the rclc Executor, the user defines the total number of callbacks. The necessary dynamic memory will be allocated only in this phase and no more memory in the running phase. This makes this Executor static in the sense, that during runtime no additional callbacks can be added. 
+
+Also in the XRCE-DDS middleware the maximum number of handles need to be configured. See [Memory Management Tutorial](https://docs.vulcanexus.org/en/humble/rst/tutorials/micro/memory_management/memory_management.html#entity-creation) for the defaults and configuration of the colcon.meta configuration file.
 
 Then, the user adds handles and the corresponding callbacks (e.g. for subscriptions and timers) to the Executor. The order in which this takes place, defines later the sequential processing order during runtime.
 

--- a/rclc/README.md
+++ b/rclc/README.md
@@ -362,7 +362,7 @@ During the configuration phase, the user shall define:
 
 As the Executor is intended for embedded controllers, dynamic memory management is crucial. Therefore at initialization of the rclc Executor, the user defines the total number of callbacks. The necessary dynamic memory will be allocated only in this phase and no more memory in the running phase. This makes this Executor static in the sense, that during runtime no additional callbacks can be added. 
 
-Also in the XRCE-DDS middleware the maximum number of handles need to be configured. See [Memory Management Tutorial](https://docs.vulcanexus.org/en/humble/rst/tutorials/micro/memory_management/memory_management.html#entity-creation) for the defaults and configuration of the colcon.meta configuration file.
+Also in the XRCE-DDS middleware the maximum number of handles need to be configured. See [Memory Management Tutorial](https://docs.vulcanexus.org/en/humble/rst/tutorials/micro/memory_management/memory_management.html#entity-creation) for the defaults and configuration of the colcon.meta configuration file. To make sure that the changes were applied, you can check the defined values in the following library include file: build/rmw_microxrcedds/include/rmw_microxrcedds_c/config.h.
 
 Then, the user adds handles and the corresponding callbacks (e.g. for subscriptions and timers) to the Executor. The order in which this takes place, defines later the sequential processing order during runtime.
 

--- a/rclc/README.md
+++ b/rclc/README.md
@@ -360,7 +360,8 @@ During the configuration phase, the user shall define:
 - trigger condition (optional, default: ANY)
 - data communcation semantics (optional, default ROS2)
 
-As the Executor is intended for embedded controllers, dynamic memory management is crucial. Therefore at initialization of the rclc Executor, the user defines the total number of callbacks. The necessary dynamic memory will be allocated only in this phase and no more memory in the running phase. This makes this Executor static in the sense, that during runtime no additional callbacks can be added.
+As the Executor is intended for embedded controllers, dynamic memory management is crucial. Therefore at initialization of the rclc Executor, the user defines the total number of callbacks. The necessary dynamic memory will be allocated only in this phase and no more memory in the running phase. This makes this Executor static in the sense, that during runtime no additional callbacks can be added. Also in the XRCE-DDS middleware the maximum number
+of handles need to be configured. See [Memory Management Tutorial](https://docs.vulcanexus.org/en/humble/rst/tutorials/micro/memory_management/memory_management.html#entity-creation) for the defaults and configuration of the colcon.meta configuration file.
 
 Then, the user adds handles and the corresponding callbacks (e.g. for subscriptions and timers) to the Executor. The order in which this takes place, defines later the sequential processing order during runtime.
 

--- a/rclc/include/rclc/executor.h
+++ b/rclc/include/rclc/executor.h
@@ -101,7 +101,12 @@ rclc_executor_get_zero_initialized_executor(void);
  *  Therefore at initialization of the RCLC-Executor, the user defines the total \p number_of_handles.
  * A handle is a term for subscriptions, timers, services, clients and guard conditions. The
  * heap will be allocated only in this phase and no more memory will be allocated in the
- * running phase in the executor. However, the heap memory of corresponding wait-set is
+ * running phase in the executor.
+ *
+ * Also in the XRCE-DDS middleware the maximum number are configured. See [Memory Management Tutorial](https://docs.vulcanexus.org/en/humble/rst/tutorials/micro/memory_management/memory_management.html#entity-creation)
+ * for the default values. If you need larger values, you need to update your colcon.meta configuration file and rebuild.
+ *
+ * The heap memory of corresponding wait-set is
  * allocated in the first iteration of a spin-method, which calls internally rclc_executor_prepare.
  * Optionally, you can also call rclc_executor_prepare before calling any of the spin-methods.
  * Then all wait-set related memory allocation will be done in rclc_executor_prepare and not

--- a/rclc/include/rclc/executor.h
+++ b/rclc/include/rclc/executor.h
@@ -104,7 +104,10 @@ rclc_executor_get_zero_initialized_executor(void);
  * running phase in the executor.
  *
  * Also in the XRCE-DDS middleware the maximum number are configured. See [Memory Management Tutorial](https://docs.vulcanexus.org/en/humble/rst/tutorials/micro/memory_management/memory_management.html#entity-creation)
- * for the default values. If you need larger values, you need to update your colcon.meta configuration file and rebuild.
+ * for the default values. If you need larger values, you need to update your colcon.meta
+ * configuration file and rebuild. To make sure that the changes were applied, you can check
+ * the defined values in the following library include file:
+ * build/rmw_microxrcedds/include/rmw_microxrcedds_c/config.h
  *
  * The heap memory of corresponding wait-set is
  * allocated in the first iteration of a spin-method, which calls internally rclc_executor_prepare.


### PR DESCRIPTION
Often developers are not aware to configure xrce-dds middleware also when initializing the Executor  with `number_of_handles`.
I added docu in the `README.md`  and `executor.h` 

related issue: https://github.com/ros2/rclc/issues/325