### PR TITLE
Revert "Decouple rosout publisher init from node init. (#351)"

### DIFF
--- a/rclc/src/rclc/node.c
+++ b/rclc/src/rclc/node.c
@@ -17,8 +17,6 @@
 #include "rclc/node.h"
 
 #include <rcl/error_handling.h>
-#include <rcl/logging.h>
-#include <rcl/logging_rosout.h>
 #include <rcutils/logging_macros.h>
 
 rcl_ret_t
@@ -81,24 +79,6 @@ rclc_node_init_with_options(
     node_ops);
   if (rc != RCL_RET_OK) {
     PRINT_RCLC_WARN(rclc_node_init_with_options, rcl_node_init);
-    return rc;
   }
-
-  // The initialization for the rosout publisher
-  if (rcl_logging_rosout_enabled() && node_ops->enable_rosout) {
-    rc = rcl_logging_rosout_init_publisher_for_node(node);
-    if (rc != RCL_RET_OK) {
-      PRINT_RCLC_WARN(
-        rclc_node_init_with_options,
-        rcl_logging_rosout_init_publisher_for_node);
-      if (rcl_logging_rosout_fini_publisher_for_node(node) != RCL_RET_OK) {
-        PRINT_RCLC_WARN(
-          rclc_node_init_with_options,
-          rcl_logging_rosout_fini_publisher_for_node);
-      }
-      return rc;
-    }
-  }
-
   return rc;
 }

--- a/rclc/test/rclc/test_executor.cpp
+++ b/rclc/test/rclc/test_executor.cpp
@@ -21,8 +21,6 @@
 #include <thread>
 #include <vector>
 
-#include "rcl/logging.h"
-#include "rcl/logging_rosout.h"
 #include "rclc/executor.h"
 #include "osrf_testing_tools_cpp/scope_exit.hpp"
 #include "rcutils/time.h"
@@ -547,10 +545,6 @@ public:
     rcl_node_options_t node_options = rcl_node_get_default_options();
     ret = rcl_node_init(&this->node, name, "", &this->context, &node_options);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    if (rcl_logging_rosout_enabled() && node_options.enable_rosout) {
-      ret = rcl_logging_rosout_init_publisher_for_node(&this->node);
-      ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    }
     const rcl_node_options_t * node_ops = rcl_node_get_options(&this->node);
     this->allocator_ptr = &node_ops->allocator;
 

--- a/rclc_examples/src/example_executor_only_rcl.c
+++ b/rclc_examples/src/example_executor_only_rcl.c
@@ -15,8 +15,6 @@
 
 #include <stdio.h>
 
-#include <rcl/logging.h>
-#include <rcl/logging_rosout.h>
 #include <rclc/executor.h>
 #include <std_msgs/msg/string.h>
 
@@ -84,13 +82,6 @@ int main(int argc, const char * argv[])
   if (rc != RCL_RET_OK) {
     printf("Error in rcl_node_init\n");
     return -1;
-  }
-  if (rcl_logging_rosout_enabled() && node_ops.enable_rosout) {
-    rc = rcl_logging_rosout_init_publisher_for_node(&my_node);
-    if (rc != RCL_RET_OK) {
-      printf("Error in rcl_logging_rosout_init_publisher_for_node\n");
-      return -1;
-    }
   }
 
   // create a publisher to publish topic 'topic_0' with type std_msg::msg::String

--- a/rclc_lifecycle/test/test_lifecycle.cpp
+++ b/rclc_lifecycle/test/test_lifecycle.cpp
@@ -23,9 +23,6 @@ extern "C"
 #include <lifecycle_msgs/msg/state.h>
 #include <lifecycle_msgs/msg/transition.h>
 
-#include <rcl/logging.h>
-#include <rcl/logging_rosout.h>
-
 #include "rclc_lifecycle/rclc_lifecycle.h"
 }
 
@@ -66,9 +63,6 @@ TEST(TestRclcLifecycle, lifecycle_node) {
   rcl_node_t my_node = rcl_get_zero_initialized_node();
   rcl_node_options_t node_ops = rcl_node_get_default_options();
   res += rcl_node_init(&my_node, "lifecycle_node", "rclc", &context, &node_ops);
-  if (rcl_logging_rosout_enabled() && node_ops.enable_rosout) {
-    res += rcl_logging_rosout_init_publisher_for_node(&my_node);
-  }
 
   rclc_lifecycle_node_t lifecycle_node;
   rcl_lifecycle_state_machine_t state_machine = rcl_lifecycle_get_zero_initialized_state_machine();
@@ -106,9 +100,6 @@ TEST(TestRclcLifecycle, lifecycle_node_transitions) {
   rcl_node_t my_node = rcl_get_zero_initialized_node();
   rcl_node_options_t node_ops = rcl_node_get_default_options();
   res += rcl_node_init(&my_node, "lifecycle_node", "rclc", &context, &node_ops);
-  if (rcl_logging_rosout_enabled() && node_ops.enable_rosout) {
-    res += rcl_logging_rosout_init_publisher_for_node(&my_node);
-  }
 
   rclc_lifecycle_node_t lifecycle_node;
   rcl_lifecycle_state_machine_t state_machine = rcl_lifecycle_get_zero_initialized_state_machine();
@@ -179,9 +170,6 @@ TEST(TestRclcLifecycle, lifecycle_node_callbacks) {
   rcl_node_t my_node = rcl_get_zero_initialized_node();
   rcl_node_options_t node_ops = rcl_node_get_default_options();
   res += rcl_node_init(&my_node, "lifecycle_node", "rclc", &context, &node_ops);
-  if (rcl_logging_rosout_enabled() && node_ops.enable_rosout) {
-    res += rcl_logging_rosout_init_publisher_for_node(&my_node);
-  }
 
   rclc_lifecycle_node_t lifecycle_node;
   rcl_lifecycle_state_machine_t state_machine = rcl_lifecycle_get_zero_initialized_state_machine();
@@ -247,9 +235,6 @@ TEST(TestRclcLifecycle, lifecycle_node_servers) {
   rcl_node_t my_node = rcl_get_zero_initialized_node();
   rcl_node_options_t node_ops = rcl_node_get_default_options();
   res += rcl_node_init(&my_node, "lifecycle_node", "rclc", &context, &node_ops);
-  if (rcl_logging_rosout_enabled() && node_ops.enable_rosout) {
-    res += rcl_logging_rosout_init_publisher_for_node(&my_node);
-  }
 
   rclc_lifecycle_node_t lifecycle_node;
   rcl_lifecycle_state_machine_t state_machine = rcl_lifecycle_get_zero_initialized_state_machine();


### PR DESCRIPTION
This reverts commit b5070031f3272ee9b8d03eff386da58074049290.