### PR TITLE
Data structures interfaces for multi-threaded executor

### DIFF
--- a/rclc/include/rclc/executor.h
+++ b/rclc/include/rclc/executor.h
@@ -50,14 +50,26 @@ typedef enum
   LET
 } rclc_executor_semantics_t;
 
+typedef enum
+{
+  NONE,
+  SINGLE_THREADED,
+  MULTI_THREADED,
+  NON_POSIX,
+} rclc_executor_type_t;
+
 /// Type definition for trigger function. With the parameters:
 /// - array of executor_handles
 /// - size of array
 /// - application specific struct used in the trigger function
 typedef bool (* rclc_executor_trigger_t)(rclc_executor_handle_t *, unsigned int, void *);
 
+/// function pointer specification
+typedef struct rclc_executor_t_ rclc_executor_t;
+typedef rcl_ret_t (* rclc_executor_func_t)(rclc_executor_t *);
+
 /// Container for RCLC-Executor
-typedef struct
+struct rclc_executor_t_
 {
   /// Context (to get information if ROS is up-and-running)
   rcl_context_t * context;
@@ -83,7 +95,9 @@ typedef struct
   void * trigger_object;
   /// data communication semantics
   rclc_executor_semantics_t data_comm_semantics;
-} rclc_executor_t;
+  /// pointer to custom executor data structure
+  void * custom;
+};
 
 /**
  *  Return a rclc_executor_t struct with pointer members initialized to `NULL`

--- a/rclc/include/rclc/executor.h
+++ b/rclc/include/rclc/executor.h
@@ -71,6 +71,8 @@ typedef rcl_ret_t (* rclc_executor_func_t)(rclc_executor_t *);
 /// Container for RCLC-Executor
 struct rclc_executor_t_
 {
+  /// Type of Executor
+  rclc_executor_type_t type;
   /// Context (to get information if ROS is up-and-running)
   rcl_context_t * context;
   /// Container for dynamic array for DDS-handles

--- a/rclc/include/rclc/executor.h
+++ b/rclc/include/rclc/executor.h
@@ -65,11 +65,11 @@ typedef enum
 typedef bool (* rclc_executor_trigger_t)(rclc_executor_handle_t *, unsigned int, void *);
 
 /// function pointer specification
-typedef struct rclc_executor_t_ rclc_executor_t;
+typedef struct rclc_executor_t_s rclc_executor_t;
 typedef rcl_ret_t (* rclc_executor_func_t)(rclc_executor_t *);
 
 /// Container for RCLC-Executor
-struct rclc_executor_t_
+struct rclc_executor_t_s
 {
   /// Type of Executor
   rclc_executor_type_t type;

--- a/rclc/include/rclc/executor_handle.h
+++ b/rclc/include/rclc/executor_handle.h
@@ -165,6 +165,8 @@ typedef struct
   /// Interval variable. Flag, which is true, if new data is available from DDS queue
   /// (is set after calling rcl_take)
   bool data_available;
+  /// pointer to custom handle
+  void * custom;
 } rclc_executor_handle_t;
 
 /// Information about total number of subscriptions, guard_conditions, timers, subscription etc.


### PR DESCRIPTION
The multi-threaded executor PR is not finished yet. I'l like to provide this feature also for the Iron-release. Therefore, I'd like to have the interface definitions already in Iron. Specifically, I just need  a `custom`  pointer in `executor.h` and `executor_handle.h` .

