### PR TITLE
added impl of string parameter

### DIFF
--- a/rclc_parameter/include/rclc_parameter/rclc_parameter.h
+++ b/rclc_parameter/include/rclc_parameter/rclc_parameter.h
@@ -111,7 +111,8 @@ typedef enum rclc_parameter_type_t
   RCLC_PARAMETER_NOT_SET = 0,
   RCLC_PARAMETER_BOOL,
   RCLC_PARAMETER_INT,
-  RCLC_PARAMETER_DOUBLE
+  RCLC_PARAMETER_DOUBLE,
+  RCLC_PARAMETER_STRING
 } rclc_parameter_type_t;
 
 // RCLC parameter server options
@@ -391,6 +392,16 @@ rclc_parameter_set_double(
   rclc_parameter_server_t * parameter_server,
   const char * parameter_name,
   double value);
+
+
+
+// TODO: rename this function
+RCLC_PARAMETER_PUBLIC
+rcl_ret_t
+rclc_parameter_set_string2(
+  rclc_parameter_server_t * parameter_server,
+  const char * parameter_name,
+  const char* value);
 
 /**
  *  Get the value of an existing a RCLC bool parameter

--- a/rclc_parameter/src/rclc_parameter/parameter_server.c
+++ b/rclc_parameter/src/rclc_parameter/parameter_server.c
@@ -282,6 +282,12 @@ rclc_parameter_server_set_service_callback(
             param_server, parameter->name.data,
             request->parameters.data[i].value.double_value);
           break;
+        
+        case RCLC_PARAMETER_STRING:
+          ret = rclc_parameter_set_string2(
+            param_server, parameter->name.data, 
+            request->parameters.data[i].value.string_value.data);
+          break;
 
         default:
           rclc_parameter_set_string(message, "Type not supported");
@@ -1230,6 +1236,12 @@ rclc_add_parameter(
   parameter_server->parameter_list.data[index].value.type = type;
   ++parameter_server->parameter_list.size;
 
+
+  // allocate memory for string parameter
+  if(type == RCLC_PARAMETER_STRING){
+    rclc_parameter_descriptor_initialize_string(&parameter_server->parameter_list.data[index].value.string_value);
+  };
+
   // Add to parameter descriptors
   if (!parameter_server->low_mem_mode && !rclc_parameter_set_string(
       &parameter_server->parameter_descriptors.data[index].name,
@@ -1497,11 +1509,59 @@ rclc_parameter_set_double(
   return RCL_RET_OK;
 }
 
+rcl_ret_t rclc_parameter_set_string2(
+  rclc_parameter_server_t *parameter_server, 
+  const char *parameter_name,
+  const char *value)
+{
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    parameter_server, "parameter_server is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    parameter_name, "parameter_name is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+
+  if (parameter_server->on_callback) {
+    return RCLC_PARAMETER_DISABLED_ON_CALLBACK;
+  }
+
+  Parameter * parameter =
+    rclc_parameter_search(&parameter_server->parameter_list, parameter_name);
+
+  if (parameter == NULL) {
+    return RCL_RET_ERROR;
+  }
+
+  if (parameter->value.type != RCLC_PARAMETER_STRING) {
+    return RCLC_PARAMETER_TYPE_MISMATCH;
+  }
+  
+  rosidl_runtime_c__String blank = {};
+  Parameter new_parameter = *parameter;
+  new_parameter.value.string_value = blank;
+  rclc_parameter_descriptor_initialize_string(&new_parameter.value.string_value);
+  rclc_parameter_set_string(&new_parameter.value.string_value, value);
+  
+  if (RCL_RET_OK !=
+    rclc_parameter_execute_callback(parameter_server, parameter, &new_parameter))
+  {
+      return RCLC_PARAMETER_MODIFICATION_REJECTED;
+  }
+
+  rosidl_runtime_c__String__fini(&new_parameter.value.string_value);
+  rclc_parameter_set_string(&parameter->value.string_value, value);
+
+  if (parameter_server->notify_changed_over_dds) {
+    rclc_parameter_prepare_changed_event(&parameter_server->event_list, parameter);
+    rclc_parameter_service_publish_event(parameter_server);
+  }
+
+  return RCL_RET_OK;
+}
+
 rcl_ret_t
 rclc_parameter_get_bool(
-  rclc_parameter_server_t * parameter_server,
-  const char * parameter_name,
-  bool * output)
+    rclc_parameter_server_t *parameter_server,
+    const char *parameter_name,
+    bool *output)
 {
   RCL_CHECK_FOR_NULL_WITH_MSG(
     parameter_server, "parameter_server is a null pointer", return RCL_RET_INVALID_ARGUMENT);

--- a/rclc_parameter/src/rclc_parameter/parameter_utils.c
+++ b/rclc_parameter/src/rclc_parameter/parameter_utils.c
@@ -39,6 +39,9 @@ rclc_parameter_value_copy(
     case RCLC_PARAMETER_DOUBLE:
       dst->double_value = src->double_value;
       return RCL_RET_OK;
+    case RCLC_PARAMETER_STRING:
+      rosidl_runtime_c__String__copy(&src->string_value, &dst->string_value);
+      return RCL_RET_OK;
     case RCLC_PARAMETER_NOT_SET:
     default:
       dst->type = RCLC_PARAMETER_NOT_SET;


### PR DESCRIPTION
- **addresses** the issues described in [[rclc#416]](https://github.com/ros2/rclc/issues/416) [[rclc#201]](https://github.com/ros2/rclc/issues/201).

## Tested On
-  working with ROS 2 Humble desktop.
- failing on micro-ROS  (ESP-IDF on ESP32-S3 setup)
  ([rclc_parameter_server_set_service_callback](https://github.com/ros2/rclc/blob/6f0a9edb3cf30df0368d3abbad2fa66149e5cc65/rclc_parameter/src/rclc_parameter/parameter_server.c#L215) receives request with empty string value)

While I'm able to update other parameter types (float, int, etc). On updating the string parameter type, the Parameter sequence in  [SetParameters](https://docs.ros2.org/foxy/api/rcl_interfaces/srv/SetParameters.html) request type contains empty [ string_value ](https://docs.ros2.org/foxy/api/rcl_interfaces/msg/ParameterValue.html)

