### PR TITLE
Use target_link_libraries instead of ament_target_dependencies

### DIFF
--- a/rclc/CMakeLists.txt
+++ b/rclc/CMakeLists.txt
@@ -160,7 +160,7 @@ if(BUILD_TESTING)
     rcl::rcl
     rcutils::rcutils
     ${rosidl_generator_c_LIBRARIES}
-    osrf_testing_tools_cpp
+    ${osrf_testing_tools_cpp_TARGETS}
     ${std_msgs_TARGETS}
     ${test_msgs_TARGETS}
   )

--- a/rclc/CMakeLists.txt
+++ b/rclc/CMakeLists.txt
@@ -79,11 +79,11 @@ target_include_directories(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME} ${CMAKE_THREAD_LIBS_INIT})
 # specific order: dependents before dependencies
-ament_target_dependencies(${PROJECT_NAME}
-  rcl
-  rcl_action
-  rcutils
-  rosidl_generator_c
+target_link_libraries(${PROJECT_NAME}
+  rcl::rcl
+  rcl_action::rcl_action
+  rcutils::rcutils
+  ${rosidl_generator_c_LIBRARIES}
 )
 
 #################################################
@@ -153,16 +153,16 @@ if(BUILD_TESTING)
 
   target_include_directories(${PROJECT_NAME}_test PRIVATE include src)
   target_link_libraries(${PROJECT_NAME}_test ${PROJECT_NAME})
-  ament_target_dependencies(${PROJECT_NAME}_test
-    rclcpp
-    rclcpp_action
-    rcl
-    rcutils
-    rosidl_generator_c
+  target_link_libraries(${PROJECT_NAME}_test
+    ${example_interfaces_TARGETS}
+    rclcpp::rclcpp
+    rclcpp_action::rclcpp_action
+    rcl::rcl
+    rcutils::rcutils
+    ${rosidl_generator_c_LIBRARIES}
     osrf_testing_tools_cpp
-    std_msgs
-    test_msgs
-    example_interfaces
+    ${std_msgs_TARGETS}
+    ${test_msgs_TARGETS}
   )
 
 

--- a/rclc_examples/CMakeLists.txt
+++ b/rclc_examples/CMakeLists.txt
@@ -31,41 +31,41 @@ find_package(Threads REQUIRED)
 include_directories(include)
 
 add_executable(example_executor src/example_executor.c)
-ament_target_dependencies(example_executor rcl rclc std_msgs)
+target_link_libraries(example_executor rcl::rcl rclc::rclc ${std_msgs_TARGETS})
 
 add_executable(example_executor_only_rcl src/example_executor_only_rcl.c)
-ament_target_dependencies(example_executor_only_rcl rcl rclc std_msgs)
+target_link_libraries(example_executor_only_rcl rcl::rcl rclc::rclc ${std_msgs_TARGETS})
 
 add_executable(example_executor_trigger src/example_executor_trigger.c)
-ament_target_dependencies(example_executor_trigger rcl rclc std_msgs)
+target_link_libraries(example_executor_trigger rcl::rcl rclc::rclc ${std_msgs_TARGETS})
 
 add_executable(example_service_node src/example_service_node.c)
-ament_target_dependencies(example_service_node rcl rclc example_interfaces)
+target_link_libraries(example_service_node rcl::rcl rclc::rclc ${example_interfaces_TARGETS})
 
 add_executable(example_client_node src/example_client_node.c)
-ament_target_dependencies(example_client_node rcl rclc example_interfaces)
+target_link_libraries(example_client_node rcl::rcl rclc::rclc ${example_interfaces_TARGETS})
 
 add_executable(example_lifecycle_node src/example_lifecycle_node.c)
-ament_target_dependencies(example_lifecycle_node rcutils rcl rcl_lifecycle rclc rclc_lifecycle lifecycle_msgs)
+target_link_libraries(example_lifecycle_node rcutils::rcutils rcl::rcl rcl_lifecycle::rcl_lifecycle rclc::rclc rclc_lifecycle::rclc_lifecycle ${lifecycle_msgs_TARGETS})
 
 add_executable(example_parameter_server src/example_parameter_server.c)
-ament_target_dependencies(example_parameter_server rclc rclc_parameter)
+target_link_libraries(example_parameter_server rclc::rclc rclc_parameter::rclc_parameter)
 
 add_executable(example_sub_context src/example_sub_context.c)
-ament_target_dependencies(example_sub_context rcl rclc std_msgs)
+target_link_libraries(example_sub_context rcl::rcl rclc::rclc ${std_msgs_TARGETS})
 
 add_executable(example_pingpong src/example_pingpong.cpp)
-ament_target_dependencies(example_pingpong rcl rclc std_msgs)
+target_link_libraries(example_pingpong rcl::rcl rclc::rclc ${std_msgs_TARGETS})
 
 add_executable(example_action_server src/example_action_server.c)
 target_link_libraries(example_action_server Threads::Threads)
-ament_target_dependencies(example_action_server rcl rcl_action rclc example_interfaces)
+target_link_libraries(example_action_server rcl::rcl rcl_action::rcl_action rclc::rclc ${example_interfaces_TARGETS})
 
 add_executable(example_action_client src/example_action_client.c)
-ament_target_dependencies(example_action_client rcl rcl_action rclc example_interfaces)
+target_link_libraries(example_action_client rcl::rcl rcl_action::rcl_action rclc::rclc ${example_interfaces_TARGETS})
 
 add_executable(example_short_timer_long_subscription src/example_short_timer_long_subscription.c)
-ament_target_dependencies(example_short_timer_long_subscription rcl rclc std_msgs)
+target_link_libraries(example_short_timer_long_subscription rcl::rcl rclc::rclc ${std_msgs_TARGETS})
 
 install(TARGETS
   example_executor

--- a/rclc_lifecycle/CMakeLists.txt
+++ b/rclc_lifecycle/CMakeLists.txt
@@ -97,7 +97,7 @@ if(BUILD_TESTING)
     rcl_lifecycle::rcl_lifecycle
     rclc::rclc
     ${lifecycle_msgs_TARGETS}
-    osrf_testing_tools_cpp
+    ${osrf_testing_tools_cpp_TARGETS}
   )
 endif()
 

--- a/rclc_lifecycle/CMakeLists.txt
+++ b/rclc_lifecycle/CMakeLists.txt
@@ -42,12 +42,12 @@ target_include_directories(${PROJECT_NAME}
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
 )
 target_link_libraries(${PROJECT_NAME} ${CMAKE_THREAD_LIBS_INIT})
-ament_target_dependencies(${PROJECT_NAME}
-  rclc
-  rcutils
-  rcl_lifecycle
-  std_msgs
-  lifecycle_msgs
+target_link_libraries(${PROJECT_NAME}
+  rclc::rclc
+  rcutils::rcutils
+  rcl_lifecycle::rcl_lifecycle
+  ${std_msgs_TARGETS}
+  ${lifecycle_msgs_TARGETS}
 )
 
 # Causes the visibility macros to use dllexport rather than dllimport,
@@ -92,11 +92,11 @@ if(BUILD_TESTING)
 
   target_include_directories(${PROJECT_NAME}_test PRIVATE include src)
   target_link_libraries(${PROJECT_NAME}_test ${PROJECT_NAME})
-  ament_target_dependencies(${PROJECT_NAME}_test
-    rcl
-    rcl_lifecycle
-    rclc
-    lifecycle_msgs
+  target_link_libraries(${PROJECT_NAME}_test
+    rcl::rcl
+    rcl_lifecycle::rcl_lifecycle
+    rclc::rclc
+    ${lifecycle_msgs_TARGETS}
     osrf_testing_tools_cpp
   )
 endif()

--- a/rclc_parameter/CMakeLists.txt
+++ b/rclc_parameter/CMakeLists.txt
@@ -120,7 +120,7 @@ if(BUILD_TESTING)
     rcl::rcl
     rcutils::rcutils
     ${rosidl_generator_c_LIBRARIES}
-    osrf_testing_tools_cpp
+    ${osrf_testing_tools_cpp_TARGETS}
     ${std_msgs_TARGETS}
     ${example_interfaces_TARGETS}
   )

--- a/rclc_parameter/CMakeLists.txt
+++ b/rclc_parameter/CMakeLists.txt
@@ -56,13 +56,13 @@ target_include_directories(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME} ${CMAKE_THREAD_LIBS_INIT})
 
-ament_target_dependencies(${PROJECT_NAME}
-  rcl
-  rclc
-  rcutils
-  builtin_interfaces
-  rcl_interfaces
-  rosidl_runtime_c
+target_link_libraries(${PROJECT_NAME}
+  rcl::rcl
+  rclc::rclc
+  rcutils::rcutils
+  ${builtin_interfaces_TARGETS}
+  ${rcl_interfaces_TARGETS}
+  rosidl_runtime_c::rosidl_runtime_c
 )
 
 
@@ -114,15 +114,15 @@ if(BUILD_TESTING)
 
   target_include_directories(${PROJECT_NAME}_test PRIVATE include src)
   target_link_libraries(${PROJECT_NAME}_test ${PROJECT_NAME})
-  ament_target_dependencies(${PROJECT_NAME}_test
-    rclcpp
-    rclc
-    rcl
-    rcutils
-    rosidl_generator_c
+  target_link_libraries(${PROJECT_NAME}_test
+    rclcpp::rclcpp
+    rclc::rclc
+    rcl::rcl
+    rcutils::rcutils
+    ${rosidl_generator_c_LIBRARIES}
     osrf_testing_tools_cpp
-    std_msgs
-    example_interfaces
+    ${std_msgs_TARGETS}
+    ${example_interfaces_TARGETS}
   )
 endif()
 


### PR DESCRIPTION
## Description

Remove deprecated `ament_target_dependencies` in favor of `target_link_libraries`.
Related to https://github.com/ament/ament_cmake/issues/292 and this failing CI https://github.com/ros2/rclc/actions/runs/15155454962

### Is this user-facing behavior change?

### Did you use Generative AI?

No

### Additional Information

