### PR TITLE
Bump setup-ros

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
     container:
       image: ${{ matrix.docker_image }}
     steps:
-    - uses: actions/checkout@v3
-    - uses: ros-tooling/setup-ros@0.7.9
+    - uses: actions/checkout@v4
+    - uses: ros-tooling/setup-ros@0.7.13
       with:
         use-ros2-testing: true
         required-ros-distributions: ${{ matrix.ros_distribution }}
@@ -35,7 +35,7 @@ jobs:
         apt-get install ros-${{ matrix.ros_distribution }}-rclcpp-action
         apt-get install ros-${{ matrix.ros_distribution }}-mimick-vendor
         apt-get -y install ros-${{ matrix.ros_distribution }}-performance-test-fixture
-    - uses : ros-tooling/action-ros-ci@0.3.13
+    - uses : ros-tooling/action-ros-ci@0.4.3
       with:
         package-name: "rclc rclc_examples rclc_lifecycle rclc_parameter"
         target-ros2-distro: ${{ matrix.ros_distribution }}


### PR DESCRIPTION
## Description

Bump setup-ros version in CI to 0.7.13.

Fixes failing CI due to signature changes in ROS repositories.

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information
