### PR TITLE
windows port

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
     container:
       image: ${{ matrix.docker_image }}
     steps:
-    - uses: actions/checkout@v3
-    - uses: ros-tooling/setup-ros@0.6.3
+    - uses: actions/checkout@v5
+    - uses: ros-tooling/setup-ros@0.7.15
       with:
         use-ros2-testing: true
         required-ros-distributions: ${{ matrix.ros_distribution }}
@@ -35,7 +35,7 @@ jobs:
         apt-get install ros-${{ matrix.ros_distribution }}-rclcpp-action
         apt-get install ros-${{ matrix.ros_distribution }}-mimick-vendor
         apt-get -y install ros-${{ matrix.ros_distribution }}-performance-test-fixture
-    - uses : ros-tooling/action-ros-ci@0.3.5
+    - uses : ros-tooling/action-ros-ci@0.4.5
       with:
         package-name: "rclc rclc_examples rclc_lifecycle rclc_parameter"
         target-ros2-distro: ${{ matrix.ros_distribution }}

--- a/rclc/include/rclc/executor.h
+++ b/rclc/include/rclc/executor.h
@@ -428,6 +428,7 @@ rclc_executor_add_service(
  * \return `RCL_RET_INVALID_ARGUMENT` if any parameter is a null pointer
  * \return `RCL_RET_ERROR` if any other error occured
  */
+RCLC_PUBLIC
 rcl_ret_t
 rclc_executor_add_action_client(
   rclc_executor_t * executor,
@@ -467,7 +468,7 @@ rclc_executor_add_action_client(
  * \return `RCL_RET_INVALID_ARGUMENT` if any parameter is a null pointer
  * \return `RCL_RET_ERROR` if any other error occured
  */
-
+RCLC_PUBLIC
 rcl_ret_t
 rclc_executor_add_action_server(
   rclc_executor_t * executor,

--- a/rclc_examples/src/example_action_client.c
+++ b/rclc_examples/src/example_action_client.c
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 #include <stdio.h>
-#include <unistd.h>
 
 #include <rcl/rcl.h>
 #include <rcl/error_handling.h>
@@ -191,7 +190,7 @@ int main()
     (void *) &action_client
   );
 
-  sleep(1);
+  rclc_sleep_ms(1000);
 
   if (RCL_RET_OK !=
     rclc_action_send_goal_request(&action_client, &ros_goal_request[0], NULL))
@@ -202,7 +201,7 @@ int main()
 
   while (!goals_completed) {
     rclc_executor_spin_some(&executor, RCL_MS_TO_NS(10));
-    usleep(100000);
+    rclc_sleep_ms(100);
   }
 
   // clean up

--- a/rclc_examples/src/example_action_server.c
+++ b/rclc_examples/src/example_action_server.c
@@ -14,8 +14,11 @@
 // limitations under the License.
 
 #include <stdio.h>
-#include <unistd.h>
-#include <pthread.h>
+#ifdef _WIN32
+  #include <windows.h>
+#else
+  #include <pthread.h>
+#endif
 
 #include <rcl/rcl.h>
 #include <rcl/error_handling.h>
@@ -28,7 +31,11 @@ const char * goalResult[] =
 {[GOAL_STATE_SUCCEEDED] = "succeeded", [GOAL_STATE_CANCELED] = "canceled",
   [GOAL_STATE_ABORTED] = "aborted"};
 
+#ifdef _WIN32
+DWORD WINAPI fibonacci_worker(LPVOID args)
+#else
 void * fibonacci_worker(void * args)
+#endif
 {
   (void) args;
   rclc_action_goal_handle_t * goal_handle = (rclc_action_goal_handle_t *) args;
@@ -63,7 +70,7 @@ void * fibonacci_worker(void * args)
       }
 
       rclc_action_publish_feedback(goal_handle, &feedback);
-      usleep(100000);
+      rclc_sleep_ms(100);
     }
 
     if (!goal_handle->goal_cancelled) {
@@ -81,11 +88,15 @@ void * fibonacci_worker(void * args)
   rcl_ret_t rc;
   do {
     rc = rclc_action_send_result(goal_handle, goal_state, &response);
-    usleep(1e6);
+    rclc_sleep_ms(1e3);
   } while (rc != RCL_RET_OK);
 
   free(feedback.feedback.sequence.data);
+#ifdef _WIN32
+  return 0;
+#else
   pthread_exit(NULL);
+#endif
 }
 
 rcl_ret_t handle_goal(rclc_action_goal_handle_t * goal_handle, void * context)
@@ -103,8 +114,14 @@ rcl_ret_t handle_goal(rclc_action_goal_handle_t * goal_handle, void * context)
 
   printf("Goal %d accepted\n", req->goal.order);
 
+#ifdef _WIN32
+  HANDLE thread_id = CreateThread(
+    NULL, 0, (LPTHREAD_START_ROUTINE) fibonacci_worker, goal_handle, 0, NULL);
+  CloseHandle(thread_id);  // libère immédiatement le handle, le thread continue
+#else
   pthread_t * thread_id = malloc(sizeof(pthread_t));
   pthread_create(thread_id, NULL, fibonacci_worker, goal_handle);
+#endif
   return RCL_RET_ACTION_GOAL_ACCEPTED;
 }
 
@@ -161,7 +178,7 @@ int main()
 
   while (1) {
     rclc_executor_spin_some(&executor, RCL_MS_TO_NS(10));
-    usleep(100000);
+    rclc_sleep_ms(100);
   }
 
   // clean up

--- a/rclc_examples/src/example_parameter_server.c
+++ b/rclc_examples/src/example_parameter_server.c
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 #include <stdio.h>
-#include <unistd.h>
 
 #include <rcl/rcl.h>
 #include <rcl/error_handling.h>

--- a/rclc_examples/src/example_sub_context.c
+++ b/rclc_examples/src/example_sub_context.c
@@ -74,15 +74,19 @@ int main(int argc, const char * argv[])
     {100, "bar counting from 100"},
     {300, "baz counting from 300"},
   };
-  rcl_publisher_t my_pubs[n_topics];
-  std_msgs__msg__String pub_msgs[n_topics];
-  rcl_subscription_t my_subs[n_topics];
-  std_msgs__msg__String sub_msgs[n_topics];
+  rcl_publisher_t * my_pubs = malloc(sizeof(rcl_publisher_t) * n_topics);
+  std_msgs__msg__String * pub_msgs = malloc(sizeof(std_msgs__msg__String) * n_topics);
+  rcl_subscription_t * my_subs = malloc(sizeof(rcl_subscription_t) * n_topics);
+  std_msgs__msg__String * sub_msgs = malloc(sizeof(std_msgs__msg__String) * n_topics);
 
   // create init_options
   rc = rclc_support_init(&support, argc, argv, &allocator);
   if (rc != RCL_RET_OK) {
     printf("Error rclc_support_init.\n");
+    free(my_pubs);
+    free(pub_msgs);
+    free(my_subs);
+    free(sub_msgs);
     return -1;
   }
 
@@ -91,6 +95,10 @@ int main(int argc, const char * argv[])
   rc = rclc_node_init_default(&my_node, "node_0", "executor_examples", &support);
   if (rc != RCL_RET_OK) {
     printf("Error in rclc_node_init_default\n");
+    free(my_pubs);
+    free(pub_msgs);
+    free(my_subs);
+    free(sub_msgs);
     return -1;
   }
 
@@ -106,6 +114,10 @@ int main(int argc, const char * argv[])
       topic_names[i]);
     if (RCL_RET_OK != rc) {
       printf("Error in rclc_publisher_init_default %s.\n", topic_names[i]);
+      free(my_pubs);
+      free(pub_msgs);
+      free(my_subs);
+      free(sub_msgs);
       return -1;
     }
     // assign message to publisher
@@ -127,6 +139,10 @@ int main(int argc, const char * argv[])
       topic_names[i]);
     if (rc != RCL_RET_OK) {
       printf("Failed to create subscriber %s.\n", topic_names[i]);
+      free(my_pubs);
+      free(pub_msgs);
+      free(my_subs);
+      free(sub_msgs);
       return -1;
     } else {
       printf("Created subscriber %s:\n", topic_names[i]);
@@ -205,7 +221,15 @@ int main(int argc, const char * argv[])
 
   if (rc != RCL_RET_OK) {
     printf("Error while cleaning up!\n");
+    free(my_pubs);
+    free(pub_msgs);
+    free(my_subs);
+    free(sub_msgs);
     return -1;
   }
+  free(my_pubs);
+  free(pub_msgs);
+  free(my_subs);
+  free(sub_msgs);
   return 0;
 }


### PR DESCRIPTION
## Description

This MR adds Windows support for the rclc package, especially for action-related features and examples (rclc_examples). It replaces Unix-specific system calls with cross-platform alternatives or conditionally compiles platform-specific code where needed.

Main Changes

- Conditional replacement of:
    - #include <unistd.h> → wrapped with #ifdef _WIN32
    - usleep(...) → replaced with rclc_sleep_ms(...) (cross-platform sleep utility)
    - pthread → replaced by CreateThread and CloseHandle on Windows
- Action server threading
    - fibonacci_worker() is now implemented with:
    - DWORD WINAPI for Windows threads
    - void * for POSIX threads
- Thread creation:
    - On Windows: CreateThread(...) with immediate CloseHandle
    - On Unix: pthread_create(...) as before

Tested on
- Windows 11 + ROS 2 Humble + Visual Studio 2022

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

~~Fixes # (issue)~~

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

- PR descrition
- fibonacci_worker()
- rclc_examples/src/example_sub_context.c

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
