### PR TITLE
Compatiblity with 'Populate Transitions' ros2/rcl#1269

### DIFF
--- a/rclc_examples/src/example_lifecycle_node.c
+++ b/rclc_examples/src/example_lifecycle_node.c
@@ -87,6 +87,7 @@ int main(int argc, const char * argv[])
   rc = rclc_make_node_a_lifecycle_node(
     &lifecycle_node,
     &my_node,
+    &support.clock,
     &state_machine_,
     &allocator,
     true);

--- a/rclc_lifecycle/include/rclc_lifecycle/rclc_lifecycle.h
+++ b/rclc_lifecycle/include/rclc_lifecycle/rclc_lifecycle.h
@@ -108,6 +108,7 @@ rcl_ret_t
 rclc_make_node_a_lifecycle_node(
   rclc_lifecycle_node_t * lifecycle_node,
   rcl_node_t * node,
+  rcl_clock_t * clock,
   rcl_lifecycle_state_machine_t * state_machine,
   rcl_allocator_t * allocator,
   bool enable_communication_interface);

--- a/rclc_lifecycle/src/rclc_lifecycle/rclc_lifecycle.c
+++ b/rclc_lifecycle/src/rclc_lifecycle/rclc_lifecycle.c
@@ -38,6 +38,7 @@ rcl_ret_t
 rclc_make_node_a_lifecycle_node(
   rclc_lifecycle_node_t * lifecycle_node,
   rcl_node_t * node,
+  rcl_clock_t * clock,
   rcl_lifecycle_state_machine_t * state_machine,
   rcl_allocator_t * allocator,
   bool enable_communication_interface
@@ -47,6 +48,8 @@ rclc_make_node_a_lifecycle_node(
     lifecycle_node, "lifecycle_node is a null pointer", return RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_FOR_NULL_WITH_MSG(
     node, "node is a null pointer", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    clock, "clock is a null pointer", return RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_FOR_NULL_WITH_MSG(
     allocator, "allocator is a null pointer", return RCL_RET_INVALID_ARGUMENT);
 
@@ -61,6 +64,7 @@ rclc_make_node_a_lifecycle_node(
   rcl_ret_t rcl_ret = rcl_lifecycle_state_machine_init(
     state_machine,
     node,
+    clock,
     ROSIDL_GET_MSG_TYPE_SUPPORT(lifecycle_msgs, msg, TransitionEvent),
     ROSIDL_GET_SRV_TYPE_SUPPORT(lifecycle_msgs, srv, ChangeState),
     ROSIDL_GET_SRV_TYPE_SUPPORT(lifecycle_msgs, srv, GetState),

--- a/rclc_lifecycle/test/test_lifecycle.cpp
+++ b/rclc_lifecycle/test/test_lifecycle.cpp
@@ -64,12 +64,16 @@ TEST(TestRclcLifecycle, lifecycle_node) {
   rcl_node_options_t node_ops = rcl_node_get_default_options();
   res += rcl_node_init(&my_node, "lifecycle_node", "rclc", &context, &node_ops);
 
+  rcl_clock_t my_clock;
+  res += rcl_clock_init(RCL_SYSTEM_TIME, &my_clock, &allocator);
+
   rclc_lifecycle_node_t lifecycle_node;
   rcl_lifecycle_state_machine_t state_machine = rcl_lifecycle_get_zero_initialized_state_machine();
 
   res += rclc_make_node_a_lifecycle_node(
     &lifecycle_node,
     &my_node,
+    &my_clock,
     &state_machine,
     &allocator,
     true);
@@ -81,6 +85,8 @@ TEST(TestRclcLifecycle, lifecycle_node) {
     rcl_lifecycle_state_machine_is_initialized(lifecycle_node.state_machine));
 
   // clean up
+  res = rcl_clock_fini(&my_clock);
+  EXPECT_EQ(RCL_RET_OK, res);
   res = rcl_node_fini(&my_node);
   EXPECT_EQ(RCL_RET_OK, res);
   res = rcl_node_options_fini(&node_ops);
@@ -101,12 +107,16 @@ TEST(TestRclcLifecycle, lifecycle_node_transitions) {
   rcl_node_options_t node_ops = rcl_node_get_default_options();
   res += rcl_node_init(&my_node, "lifecycle_node", "rclc", &context, &node_ops);
 
+  rcl_clock_t my_clock;
+  res += rcl_clock_init(RCL_ROS_TIME, &my_clock, &allocator);
+
   rclc_lifecycle_node_t lifecycle_node;
   rcl_lifecycle_state_machine_t state_machine = rcl_lifecycle_get_zero_initialized_state_machine();
 
   res += rclc_make_node_a_lifecycle_node(
     &lifecycle_node,
     &my_node,
+    &my_clock,
     &state_machine,
     &allocator,
     false);
@@ -151,6 +161,8 @@ TEST(TestRclcLifecycle, lifecycle_node_transitions) {
     lifecycle_msgs__msg__State__PRIMARY_STATE_UNCONFIGURED,
     lifecycle_node.state_machine->current_state->id);
 
+  res = rcl_clock_fini(&my_clock);
+  EXPECT_EQ(RCL_RET_OK, res);
   res = rcl_node_fini(&my_node);
   EXPECT_EQ(RCL_RET_OK, res);
   res = rcl_node_options_fini(&node_ops);
@@ -171,12 +183,16 @@ TEST(TestRclcLifecycle, lifecycle_node_callbacks) {
   rcl_node_options_t node_ops = rcl_node_get_default_options();
   res += rcl_node_init(&my_node, "lifecycle_node", "rclc", &context, &node_ops);
 
+  rcl_clock_t my_clock;
+  res += rcl_clock_init(RCL_ROS_TIME, &my_clock, &allocator);
+
   rclc_lifecycle_node_t lifecycle_node;
   rcl_lifecycle_state_machine_t state_machine = rcl_lifecycle_get_zero_initialized_state_machine();
 
   res += rclc_make_node_a_lifecycle_node(
     &lifecycle_node,
     &my_node,
+    &my_clock,
     &state_machine,
     &allocator,
     true);
@@ -216,6 +232,8 @@ TEST(TestRclcLifecycle, lifecycle_node_callbacks) {
   EXPECT_EQ(RCL_RET_OK, res);
   EXPECT_EQ(15, callback_mockup_counter);
 
+  res = rcl_clock_fini(&my_clock);
+  EXPECT_EQ(RCL_RET_OK, res);
   res = rcl_node_fini(&my_node);
   EXPECT_EQ(RCL_RET_OK, res);
   res = rcl_node_options_fini(&node_ops);
@@ -236,12 +254,16 @@ TEST(TestRclcLifecycle, lifecycle_node_servers) {
   rcl_node_options_t node_ops = rcl_node_get_default_options();
   res += rcl_node_init(&my_node, "lifecycle_node", "rclc", &context, &node_ops);
 
+  rcl_clock_t my_clock;
+  res += rcl_clock_init(RCL_ROS_TIME, &my_clock, &allocator);
+
   rclc_lifecycle_node_t lifecycle_node;
   rcl_lifecycle_state_machine_t state_machine = rcl_lifecycle_get_zero_initialized_state_machine();
 
   res += rclc_make_node_a_lifecycle_node(
     &lifecycle_node,
     &my_node,
+    &my_clock,
     &state_machine,
     &allocator,
     true);
@@ -285,6 +307,8 @@ TEST(TestRclcLifecycle, lifecycle_node_servers) {
 
   // Cleanup
   res = rclc_lifecycle_node_fini(&lifecycle_node, &allocator);
+  EXPECT_EQ(RCL_RET_OK, res);
+  res = rcl_clock_fini(&my_clock);
   EXPECT_EQ(RCL_RET_OK, res);
   res = rcl_node_fini(&my_node);
   EXPECT_EQ(RCL_RET_OK, res);


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
Compatibility with ros2/rcl#1269
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->
Yes, the timestamp and transition field of a lifecycle_msg/TransitionEvent will be filled.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->
No.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
Requires ros2/rcl#1269